### PR TITLE
Default DCC to LWTOOLS

### DIFF
--- a/Source/Compiler/CC09/bool.c
+++ b/Source/Compiler/CC09/bool.c
@@ -16,10 +16,7 @@ extern direct expnode *dregcont,*xregcont;
 #endif
 
 
-expnode *
-tranbool(node,tlab,flab,nj)
-register expnode *node;
-labstruc *tlab,*flab;
+expnode *tranbool(register expnode *node, labstruc *tlab, labstruc *flab, int nj)
 {
     int op;
     labstruc second;
@@ -57,8 +54,8 @@ l1:         uselabel(&second);
         case FCONST:
 #endif
         case LCONST:
-            if (node->val.num && nj == FALSE) gen(JMP,setlabel(tlab),0);
-            else if (nj && node->val.num == 0) gen(JMP,setlabel(flab),0);
+            if (node->val.num && nj == FALSE) gen(JMP,setlabel(tlab),0,0);
+            else if (nj && node->val.num == 0) gen(JMP,setlabel(flab),0,0);
             break;
         case COMMA:
             tranexp(node->left);
@@ -67,24 +64,22 @@ l1:         uselabel(&second);
         default:
             if(islong(node)) {
                 lload(node);
-                gen(LONGOP,TEST);
+                gen(LONGOP,TEST,0,0);
             }
 #ifdef  DOFLOATS
             else if(isfloat(node)) {
                 if(node->op==FTOD) node=node->left;
                 dload(node);
-                gen(DBLOP,TEST,node->type);
+                gen(DBLOP,TEST,node->type,0);
             }
 #endif
             else checkop(node);
-usual:      gen(CNDJMP,(nj ? EQ:NEQ),setlabel(nj ? flab : tlab));
+usual:      gen(CNDJMP,(nj ? EQ:NEQ),setlabel(nj ? flab : tlab),0);
      }
 }
 
 
-tranrel(op,node,tlab,flab,nj)
-expnode *node;
-labstruc *tlab,*flab;
+int tranrel(int op, expnode *node, labstruc *tlab, labstruc *flab, int nj)
 {
     labstruc *destin;
     register expnode *rhs,*lhs,*t;
@@ -132,7 +127,7 @@ labstruc *tlab,*flab;
             case UREG:
             case DREG:
 ok:
-                gen(PUSH,rhs->op);
+                gen(PUSH,rhs->op,0,0);
                 rhs->op=STACK;
         }
         gen(COMPARE,temp,NODE,rhs);
@@ -145,7 +140,7 @@ ok:
         if (isdleaf(rhs) || (temp == DREG && isaleaf(rhs))) {
             tranexp(rhs);
         } else {
-            gen(PUSH,temp);
+            gen(PUSH,temp,0,0);
             lhs->op=STACK;
             loadexp(rhs);
             temp = rhs->op;
@@ -156,12 +151,11 @@ ok:
         gen(COMPARE,temp,NODE,rhs);
     }
 usual:
-    gen(CNDJMP,op,setlabel(destin));
+    gen(CNDJMP,op,setlabel(destin),0);
 }
 
 
-setlabel(lab)
-register labstruc *lab;
+int setlabel(register labstruc *lab)
 {
     if (lab) {
         if (lab->labnum == 0) {
@@ -186,8 +180,7 @@ register labstruc *lab;
 }
 
 
-uselabel(lab)
-register labstruc *lab;
+int uselabel(register labstruc *lab)
 {
     if (lab->labnum) {
 #ifdef REGCONTS
@@ -202,8 +195,7 @@ register labstruc *lab;
 }
 
 
-isaleaf(node)
-expnode *node;
+int isaleaf(expnode *node)
 {
      switch(node->op) {
           case NAME:case CONST:return 1;
@@ -213,15 +205,13 @@ expnode *node;
 }
 
 
-isauto(p)
-expnode *p;
+int isauto(expnode *p)
 {
     return p->op == NAME && p->val.sp->storage == AUTO;
 }
 
 
-checkop(node)
-register expnode *node;
+int checkop(register expnode *node)
 {
     register expnode *lhs;
     int flag;
@@ -287,7 +277,7 @@ register expnode *node;
 }
 
 
-invrel(op)
+int invrel(int op)
 {
      switch(op){
           case EQ: return NEQ;
@@ -297,7 +287,7 @@ invrel(op)
 }
 
 
-revrel(op)
+int revrel(int op)
 {
       switch(op){
            case EQ:
@@ -309,8 +299,7 @@ revrel(op)
 }
 
 
-zeroconst(node)
-register expnode *node;
+int zeroconst(register expnode *node)
 {
      return node->op == CONST && !node->val.num;
 }

--- a/Source/Compiler/CC09/build.c
+++ b/Source/Compiler/CC09/build.c
@@ -10,12 +10,10 @@
 
 #include "cj.h"
 
-static elsize(prim);
+static int elsize(expnode **);
 
 
-expnode *
-parsexp(priority)
-int priority;
+expnode * parsexp(int priority)
 {
     register expnode *rhs,*lhs,*temp;
     register int op,priop,lno,rprec;
@@ -64,8 +62,7 @@ exit:
 }
 
 
-expnode *
-primary()
+expnode * primary(void)
 {
     register expnode *nodep,*prim;
     expnode *temp;
@@ -191,8 +188,7 @@ dblop:      nodep = newnode(sym,nodep,0,LEV_14,symline,symptr);
 }
 
 
-expnode *
-explist()
+expnode * explist(void)
 {
     register expnode *list = NULL, *ptr;
 
@@ -209,8 +205,7 @@ explist()
 }
 
 
-constexp(p)
-int p;
+int constexp(int p)
 {
     register expnode *ptr;
     register int v;
@@ -225,7 +220,7 @@ int p;
 }
 
 
-isop()
+int isop(void)
 {
     switch (sym) {
         case AMPER:
@@ -252,7 +247,7 @@ isop()
 }
 
 
-constop(op,r,l)
+int constop(int op, cval_t r, cval_t l)
 {
     switch(op) {
         case PLUS:      return r + l;
@@ -285,8 +280,8 @@ constop(op,r,l)
         case UGEQ:
         case UGT:
             {
-                char *lp,*rp;
-                lp = (char *) l;  rp = (char *) r;
+                unsigned int lp = l & 0xffff;
+                unsigned int rp = r & 0xffff;
                 switch (op) {
                     case ULEQ:      return rp <= lp;
                     case ULT:       return rp < lp;
@@ -300,11 +295,11 @@ constop(op,r,l)
 }
 
 
-expnode *
-getcast()
+expnode * getcast(void)
 {
     expnode *dptr,*ptr;
-    int lno,dummy,size,type;
+    int lno,dummy,type;
+    cval_t size;
     register char *errpnt;
 
     lno = symline;
@@ -325,10 +320,7 @@ getcast()
 }
 
 
-expnode *
-newnode(op,left,right,value,lno,errpnt)
-expnode *left,*right;
-char *errpnt;
+expnode *newnode(int op, expnode *left, expnode *right, cval_t value, int lno, char *errpnt)
 {
     register expnode *node;
 
@@ -348,15 +340,13 @@ char *errpnt;
 }
 
 
-experr()
+int experr(void)
 {
     error("expression missing");
 }
 
 
-static
-elsize(prim)
-expnode **prim;
+static int elsize(expnode **prim)
 {
     register expnode *p;
 
@@ -375,4 +365,3 @@ usual:      return getsize(p->type,p->size,p->dimptr);
             return elsize(&p->right);
     }
 }
-

--- a/Source/Compiler/CC09/cj.h
+++ b/Source/Compiler/CC09/cj.h
@@ -1,6 +1,9 @@
 #include <stdint.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+typedef intptr_t cval_t;
 
 /*	Canonicalize our system definitions: __unix__, _OS9, _OSK, _OS9000
  */
@@ -53,7 +56,11 @@
  */
 #ifdef __unix__
 # include <unistd.h>
-# include <endian.h>
+# ifdef __APPLE__
+#  include <machine/endian.h>
+# else
+#  include <endian.h>
+# endif
 # if BYTE_ORDER == BIG_ENDIAN
 #  define _BIG_END 1
 # elif BYTE_ORDER == LITTLE_ENDIAN
@@ -143,7 +150,7 @@ typedef struct dimstr {
 
 typedef struct downsym {
     short type;             /* type of entry */
-    int size;               /* size of entry */
+    cval_t size;            /* size of entry or pointer-sized payload */
     dimnode *dimptr;        /* ptr to list of dimensions */
     int offset;             /* general purpose */
     int storage;            /* storage class */
@@ -160,7 +167,7 @@ typedef struct downsym {
 
 typedef struct symstr {
     short type;             /* type of entry */
-    int size;               /* size of entry */
+    cval_t size;            /* size of entry or pointer-sized payload */
     dimnode *dimptr;        /* ptr to list of dimensions */
     int offset;             /* general purpose */
     int storage;            /* storage class */
@@ -179,11 +186,11 @@ typedef struct symstr {
 
 typedef struct expstr {
     short type;             /* type of node */
-    int size;               /* size of basic type */
+    cval_t size;            /* size of basic type or pointer-sized payload */
     dimnode *dimptr;        /* ptr to list of dimensions */
     short op;               /* operator */
     union {
-        int num;            /* numeric value */
+        cval_t num;         /* numeric value or pointer-sized payload */
         symnode *sp;        /* symbol pointer */
         long *lp;           /* long constant ptr */
 #ifdef DOFLOATS
@@ -503,6 +510,7 @@ global direct int   lineno,     /* current line number */
                     sp,         /* current stack pointer offset */
                     stlev,      /* stack reservation level */
                     callflag,   /* function call flag */
+                    lwflag,     /* emit LWTOOLS-compatible assembly */
                     sflag,      /* suppress stack checking code */
 #ifdef PROF
                     pflag,      /* if set generate profile calls */
@@ -515,10 +523,11 @@ global direct int   lineno,     /* current line number */
                     swflag,     /* current switch level */
                     mosflg,     /* member of structure flag */
                     sym,        /* current lexical token */
-                    symval,     /* and its associated value */
                     scount,     /* chars on current line of string */
                     symline,    /* lineno of current symbol */
                     maxpush;    /* maximum push level */
+
+global direct cval_t symval;    /* current lexical token's associated value */
 
 global char filename[FNAMESIZE];    /* current filename buffer */
 
@@ -577,10 +586,39 @@ typedef struct {
 
 
 /*  function type definitions  */
-char *grab();
+char *grab(int);
 
-extern  expnode *parsexp(), *primary(), *explist(), *getcast(),
-                *newnode(), *optim(), *fold(), *chtype(), *fixup(),
-                *tranexp(), *tranbool(), *treecopy();
+extern expnode *parsexp(int), *primary(void), *explist(void), *getcast(void);
+extern expnode *newnode(int, expnode *, expnode *, cval_t, int, char *);
+extern expnode *optim(expnode *), *fold(expnode *), *chtype(expnode *);
+extern expnode *fixup(int, int, expnode *, expnode *);
+extern expnode *tranexp(expnode *), *tranbool(expnode *, labstruc *, labstruc *, int);
+extern expnode *treecopy(expnode *);
 
-extern  dimnode *dimwalk();
+extern dimnode *dimwalk(dimnode *);
+
+extern void label(int), olbl(int), ot(char *), ol(char *), ob(int),
+            os(char *), od(cval_t), on(char *), nl(void), nlabel(char *, int);
+extern void deref(int, cval_t, int);
+extern int modstk(int);
+extern void defglob(symnode *, int, int), extstat(symnode *, int, int),
+            defvar(symnode *, int, int), locstat(int, int, int);
+#ifdef PROF
+extern void profname(char *, int);
+#endif
+#ifdef REGPARMS
+# ifdef PROF
+extern void startfunc(char *, int, int, int);
+# else
+extern void startfunc(char *, int, int);
+# endif
+#else
+# ifdef PROF
+extern void startfunc(char *, int, int);
+# else
+extern void startfunc(char *, int);
+# endif
+#endif
+extern void endfunc(void), defbyte(void), defword(void), comment(void),
+            vsect(int), endsect(void);
+extern void eprintf(char *, ...), eputs(char *), eputchar(int);

--- a/Source/Compiler/CC09/cj.h
+++ b/Source/Compiler/CC09/cj.h
@@ -300,8 +300,9 @@ typedef struct initstruct {
 
 #define SIGN        47  /* mostly ignored */
 #define SHORT       48  /* short type modifier */
+#define QUAL        49  /* const/volatile qualifier, currently ignored */
 
-/* 49..63 reserved to avoid conflicting with functions returning types */
+/* 50..63 reserved to avoid conflicting with functions returning types */
 
 #define SEMICOL     64  /* ; expression terminator */
 #define LBRACE      65  /* { block start */

--- a/Source/Compiler/CC09/cmain.c
+++ b/Source/Compiler/CC09/cmain.c
@@ -23,12 +23,11 @@ direct int eflag;
 direct  int     *inclptr;       /* include stack pointer */
 #endif     // <<<- inserted to match preceeding "ifndef PASS2"
 
-main(argc,argv)
-char **argv;
+int main(int argc, char **argv)
 {
         register char *p;
 
-        int tidy();
+        int tidy(void);
 
 #ifdef __unix__
         signal(SIGINT,tidy);
@@ -57,6 +56,8 @@ char **argv;
 #endif
                             case 's':
                                 sflag = 1; break;
+                            case 'L':
+                                lwflag = 1; break;
 #ifdef  PTREE
                             case 'd':
                                 dflag = 1;
@@ -118,7 +119,7 @@ char **argv;
 }
 
 
-errexit()
+int errexit(void)
 {
 #ifdef  SPLIT
                 if(infile)

--- a/Source/Compiler/CC09/codgen.c
+++ b/Source/Compiler/CC09/codgen.c
@@ -10,7 +10,7 @@
                         to look like "leax >a,y" instead of "leax <a".
         29-Aug-83       Function calls in the form of (*((int(*)())0xfffe))();
                         did not defreference properly.
-        26-Dec-83       Moved profexit code from gen(RETURN....) to
+        26-Dec-83       Moved profexit code from gen(RETURN....,0,0,0) to
                         allow returning local storage after call to eprof.
         17-Apr-84 LAC   Conversion for UNIX.
         01-Apr-86 LAC   clear knowledge of D contents for long and float ops.
@@ -19,8 +19,11 @@
 
 #include "cj.h"
 
-static addoff();
-static outlea();
+static int addoff(int);
+static void outlea(int), outstr(int, int);
+static void doref(int, int, cval_t, int);
+static void mwsyscall(char *), lcall(char *), fcall(char *);
+static void trouble(int, cval_t, expnode *);
 
 direct int datflag;
 
@@ -32,18 +35,17 @@ static char *lbra = "lbra ";
 static char *clra = "clra";
 static char *unkopr = "unknown operator: ";
 
-extern char *getrel(),regname();
+extern char *getrel(int);
+extern char regname(int);
 
 
-gen(op,rtype,arg,val)
-register int op,rtype;
-register expnode *val;
-register int arg;
+int gen(register int op, register int rtype, register cval_t arg, register expnode *val)
 {
     register expnode *ptr;
     register symnode *sptr;
     int reg;
-    int temp,value;
+    int temp;
+    cval_t value;
 
     if (op==LONGOP) {
         dolongs(rtype,arg);
@@ -246,7 +248,7 @@ dooff:
             ot("sub");
             goto simple;
         case RSUB:
-            gen(NEG);
+            gen(NEG,0,0,0);
         case PLUS:
             ot("add");
 simple:
@@ -300,8 +302,7 @@ leaexit:
 }
 
 
-char
-regname(r)
+char regname(int r)
 {
     switch (r) {
         case DREG:  return 'd';
@@ -315,21 +316,20 @@ regname(r)
 }
 
 
-transfer(r1,r2)
+int transfer(int r1, int r2)
 {
     fprintf(code," tfr %c,%c\n",r1,r2);
 }
 
 
-dolongs(op,arg)
-int *arg;
+int dolongs(int op, int *arg)
 {
     switch (op) {
         case STACK:
             gen(LOAD,DREG,XIND,2);
-            gen(PUSH,DREG);
+            gen(PUSH,DREG,0,0);
             gen(LOAD,DREG,XIND,0);
-            gen(PUSH,DREG);
+            gen(PUSH,DREG,0,0);
             break;
         case TEST:
             ol("lda 0,x\n ora 1,x\n ora 2,x\n ora 3,x");
@@ -385,8 +385,7 @@ int *arg;
     these breaks are returns, because setdreg() isn't used.
 */
 #ifdef  DOFLOATS
-dofloats(op,arg)
-register int arg;
+int dofloats(int op, register int arg)
 {
     switch (op) {
         case FCONST:    getcon(arg,DOUBLESIZE/2,TRUE); break;
@@ -433,8 +432,7 @@ register int arg;
 #endif
 
 
-getcon(p,n,f)
-int *p;
+int getcon(int *p, int n, int f)
 {
     int temp;
 
@@ -446,12 +444,10 @@ int *p;
 }
 
 #ifdef IEEE_FLOATS
-double dadjust();
+double dadjust(double);
 #endif
 
-defcon(p,n,f)
-register int16_t *p;
-int n, f;
+int defcon(register int16_t *p, int n, int f)
 {
     register int i;
 
@@ -520,7 +516,7 @@ int n, f;
 }
 
 
-mwsyscall(s)
+static void mwsyscall(char *s)
 {
     ot(lbsr);
     ol(s);
@@ -528,7 +524,7 @@ mwsyscall(s)
 }
 
 
-lcall(s)
+static void lcall(char *s)
 {
     ot(lbsr);
     ol(s);
@@ -536,16 +532,14 @@ lcall(s)
 }
 
 
-fcall(s)
+static void fcall(char *s)
 {
     ot(lbsr);
     ol(s);
 }
 
 
-trouble(op,arg,val)
-register int op,arg;
-register expnode *val;
+static void trouble(register int op, register cval_t arg, register expnode *val)
 {
     char *s;
     int cflag,temp;
@@ -579,7 +573,7 @@ register expnode *val;
             }
             break;
         case CONST:
-            switch (temp = ((int)val >> 8) & 0xff) {
+            switch (temp = ((cval_t)val >> 8) & 0xff) {
                 case 0:
                     if (op == AND) ol(clra);
                     break;
@@ -593,7 +587,7 @@ register expnode *val;
                     ot(s);
                     doref('a',CONST,temp,0);
             }
-            switch (temp = (int)val & 255) {
+            switch (temp = (cval_t)val & 255) {
                 case 0:
                     if (op == AND) ol("clrb");
                     break;
@@ -619,7 +613,7 @@ register expnode *val;
 }
 
 
-doref(reg,arg,val,offset)
+static void doref(int reg, int arg, cval_t val, int offset)
 {
     ob(reg);
     ob(' ');
@@ -628,9 +622,7 @@ doref(reg,arg,val,offset)
 }
 
 
-static
-addoff(offset)
-register int offset;
+static int addoff(register int offset)
 {
     if(offset) {
         if(offset > 0) ob('+');
@@ -639,7 +631,7 @@ register int offset;
 }
 
 
-deref(arg,val,offset)
+void deref(int arg, cval_t val, int offset)
 {
     register expnode *node;
     register symnode *sn;
@@ -724,8 +716,7 @@ dooff:
 }
 
 
-char *
-getrel(op)
+char *getrel(int op)
 {
     switch (op) {
         default:    error("rel op");
@@ -743,40 +734,39 @@ getrel(op)
 }
 
 
-ot(s)
+void ot(char *s)
 {
     putc(' ',code);
     os(s);
 }
 
 
-ol(s)
+void ol(char *s)
 {
     ot(s);
     nl();
 }
 
 
-nl()
+void nl(void)
 {
     putc('\n',code);
 }
 
 
-ob(b)
+void ob(int b)
 {
     putc(b,code);
 }
 
 
-os(s)
-char *s;
+void os(char *s)
 {
     fputs(s,code);
 }
 
 
-od(n)
+void od(cval_t n)
 {
 #ifdef _OS9
     fprintf(code,"%d",n & 0xFFFF);
@@ -786,7 +776,7 @@ od(n)
 }
 
 
-label(n)
+void label(int n)
 {
     olbl(n);
     lastst = 0;
@@ -794,21 +784,20 @@ label(n)
 }
 
 
-olbl(n)
+void olbl(int n)
 {
     ob(UNIQUE);
     od(n);
 }
 
 
-on(s)
-char *s;
+void on(char *s)
 {
     fprintf(code,"%.8s",s);
 }
 
 
-modstk(nsp)
+int modstk(int nsp)
 {
     int x;
 
@@ -822,7 +811,7 @@ modstk(nsp)
 }
 
 
-nlabel(ptr,scope)
+void nlabel(char *ptr, int scope)
 {
     on(ptr);
     if (scope) ob(':');
@@ -830,14 +819,13 @@ nlabel(ptr,scope)
 }
 
 
-static
-outlea(reg)
+static void outlea(int reg)
 {
     fprintf(code," lea%c ",reg);
 }
 
 
-outstr(reg,l)
+static void outstr(int reg, int l)
 {
     outlea(reg);
     fprintf(code,"%c%d,pcr\n",UNIQUE,l);

--- a/Source/Compiler/CC09/declare.c
+++ b/Source/Compiler/CC09/declare.c
@@ -25,6 +25,16 @@
 static direct int reguse;
 static direct struct initstruct *initlist,*initlast,*initfree;
 
+static void skip_proto_list(void)
+{
+    int level;
+
+    for (level = 1; level && sym != EOF; getsym()) {
+        if (sym == LPAREN) ++level;
+        else if (sym == RPAREN) --level;
+    }
+}
+
 #ifdef FUNCNAME
 direct int fnline;
 #endif
@@ -544,6 +554,11 @@ int declist(register symnode **list)
     *list = NULL;
     getsym();
 
+    if (istype()) {
+        skip_proto_list();
+        return;
+    }
+
     for (;;) {
         if (sym == RPAREN) break;
         if (sym == NAME) {
@@ -612,6 +627,8 @@ int modifier(int *size)
             if (is_long || isshort) goto err;
             isshort=1;
             break;
+        case QUAL:
+            break;
         /* final types (terminal) */
         case CHAR:
             if (is_long || isshort) goto err;
@@ -679,6 +696,7 @@ int settype(cval_t *size, dimnode **dimptr, elem **ellist)
     cval_t tsize = INTSIZE;
 
     *ellist = 0;
+    while (sym == KEYWORD && symval == QUAL) getsym();
     if (sym==KEYWORD) {
         switch (type=symval) {
             case LONG:

--- a/Source/Compiler/CC09/declare.c
+++ b/Source/Compiler/CC09/declare.c
@@ -31,16 +31,6 @@ static int is_void_name(void)
             && strncmp(((symnode *) symval)->sname, "void", NAMESIZE) == 0;
 }
 
-static void skip_proto_list(void)
-{
-    int level;
-
-    for (level = 1; level && sym != EOF; getsym()) {
-        if (sym == LPAREN) ++level;
-        else if (sym == RPAREN) --level;
-    }
-}
-
 #ifdef FUNCNAME
 direct int fnline;
 #endif
@@ -556,12 +546,56 @@ int block(int stkadj)
 int declist(register symnode **list)
 {
     register symnode *ptr,*last;
+    symnode *ptemp;
+    dimnode *dimptr;
+    cval_t size;
+    elem *eptr;
+    int type,temp;
 
     *list = NULL;
     getsym();
 
     if (istype() || is_void_name()) {
-        skip_proto_list();
+        for (;;) {
+            if (sym == RPAREN) break;
+            if (sym == DOT) {
+                while (sym != RPAREN && sym != EOF) getsym();
+                break;
+            }
+            if ((type = settype(&size,&dimptr,&eptr)) == UNDECL) type = INT;
+            if (sym == RPAREN && type == INT && is_void_name() == 0) break;
+            temp = declarator(&ptemp,&dimptr,type);
+            ptr = ptemp;
+            if (ptr) {
+                symnode *scan;
+
+                if (isftn(temp) || temp == STRUCT || temp == USTRUCT)
+                    error("argument error");
+                else if (isary(temp)) {
+                    temp = incref(decref(temp));
+                    dimptr = dimptr ? dimptr->dptr : 0;
+                }
+#ifdef DOFLOATS
+                else if (temp == FLOAT) temp = DOUBLE;
+#endif
+                for (scan = *list; scan && scan != ptr; scan = scan->snext) ;
+                if (scan) error("named twice");
+                else if (ptr->type != UNDECL || ptr->storage == ARG)
+                    pushdown(ptr);
+                ptr->type = temp;
+                ptr->storage = ARG;
+                ptr->blklev = 1;
+                ptr->x.elems = eptr;
+                sizeup(ptr,dimptr,size);
+                if (*list) last->snext = ptr;
+                else *list = ptr;
+                ptr->snext = NULL;
+                last = ptr;
+            }
+            if (sym != COMMA) break;
+            getsym();
+        }
+        need(RPAREN);
         return;
     }
 

--- a/Source/Compiler/CC09/declare.c
+++ b/Source/Compiler/CC09/declare.c
@@ -25,6 +25,12 @@
 static direct int reguse;
 static direct struct initstruct *initlist,*initlast,*initfree;
 
+static int is_void_name(void)
+{
+    return sym == NAME
+            && strncmp(((symnode *) symval)->sname, "void", NAMESIZE) == 0;
+}
+
 static void skip_proto_list(void)
 {
     int level;
@@ -81,7 +87,7 @@ int extdef(void)
         ptr = ptemp;     /* decl ptr to register */
 
         if (ptr == NULL) {
-            if (temp != STRUCT && temp != UNION) identerr();
+            if (temp != STRUCT && temp != UNION && temp != USTRUCT) identerr();
             goto next;
         }
 /*
@@ -113,7 +119,7 @@ onlist:
             ssize = sizeup(ptr,tdp,size);
             if (!isftn(temp)) {
                 if (sym == ASSIGN) initialise(ptr,tsc,temp);
-                else if (ssize == 0 && tsc!=EXTERN) sizerr();
+                else if (ssize == 0 && tsc!=EXTERN && tsc!=TYPEDEF) sizerr();
                 else switch(tsc) {
                         case STATICD:
                         case STATIC:
@@ -236,7 +242,7 @@ int blkdef(void)
         temp = declarator(&ptemp,&tdp,type);
         ptr = ptemp;
         if (ptr == NULL) {
-            if (temp != STRUCT && temp != UNION) identerr();
+            if (temp != STRUCT && temp != UNION && temp != USTRUCT) identerr();
             goto next;
         }
         if (isftn(temp) || sclass == EXTERN) {
@@ -554,7 +560,7 @@ int declist(register symnode **list)
     *list = NULL;
     getsym();
 
-    if (istype()) {
+    if (istype() || is_void_name()) {
         skip_proto_list();
         return;
     }
@@ -816,6 +822,10 @@ next:
                     break;
                 }
         }
+    } else if (is_void_name()) {
+        type = INT;
+        tsize = INTSIZE;
+        getsym();
     } else if (sym == NAME) {
         ptr = (symnode *) symval;
         if (ptr->storage == TYPEDEF) {

--- a/Source/Compiler/CC09/declare.c
+++ b/Source/Compiler/CC09/declare.c
@@ -30,12 +30,13 @@ direct int fnline;
 #endif
 
 
-extdef()
+int extdef(void)
 {
     register symnode *ptr;
     symnode *ptemp;
     dimnode *dimptr, *tdp;
-    int size,ssize,tsc,sclass,type,temp;
+    int ssize,tsc,sclass,type,temp;
+    cval_t size;
     elem *eptr;
 
     while (sym == RBRACE) {
@@ -140,12 +141,13 @@ next:
 }
 
 
-argdef()
+int argdef(void)
 {
     register symnode *ptr;
     symnode *ptemp;
     dimnode *dimptr, *tdp;
-    int sclass,type,size,stemp,temp;
+    int sclass,type,stemp,temp;
+    cval_t size;
     elem *eptr;
 
     switch (sclass = setclass()) {
@@ -199,13 +201,14 @@ next:
 }
 
 
-blkdef()
+int blkdef(void)
 {
     register symnode *ptr;
     symnode *ptemp;
     dimnode *dimptr, *tdp;
     expnode *ep;
-    int sclass,type,temp,size,stemp,ssize;
+    int sclass,type,temp,stemp,ssize;
+    cval_t size;
     elem *eptr;
     initnode *i;
 
@@ -296,10 +299,7 @@ next:
 }
 
 
-check_same(ptr,type,eptr)
-register symnode *ptr;
-register int type;
-register elem *eptr;
+int check_same(register symnode *ptr, register int type, register elem *eptr)
 {
      if (ptr->type != type
                 || (type == STRUCT && ptr->x.elems != eptr)) {
@@ -310,7 +310,7 @@ register elem *eptr;
 }
 
 
-chkreg(sclass,type)
+int chkreg(int sclass, int type)
 {
     /* if the user wants a register variable
      * and it is allowed allocate one.
@@ -343,8 +343,7 @@ chkreg(sclass,type)
 }
 
 
-newfunc(fptr,sclass)
-symnode *fptr;
+int newfunc(symnode *fptr, int sclass)
 {
     register symnode *p1;
     symnode *p2;
@@ -461,7 +460,7 @@ symnode *fptr;
 #ifdef USE_YREG
             case YREG:
 #endif
-                gen(stemp,offset-sp);
+                gen(stemp,offset-sp,0,0);
                 break;
             case ARG:
                 p1->storage = AUTO;
@@ -479,7 +478,7 @@ symnode *fptr;
 
     clear(&p2);
     clear(&labelist);
-    if (lastst != RETURN) gen(RETURN,0,0);
+    if (lastst != RETURN) gen(RETURN,0,0,0);
     lastst = 0;
 
     /* generate stack reservation */
@@ -491,8 +490,7 @@ symnode *fptr;
 }
 
 
-block(stkadj)
-int stkadj;
+int block(int stkadj)
 {
     register expnode *p;
     struct initstruct *i;
@@ -539,8 +537,7 @@ int stkadj;
 }
 
 
-declist(list)
-register symnode **list;
+int declist(register symnode **list)
 {
     register symnode *ptr,*last;
 
@@ -571,7 +568,7 @@ register symnode **list;
 }
 
 
-setclass()
+int setclass(void)
 {
      int class;
      if(issclass()) {
@@ -589,9 +586,7 @@ setclass()
      return 0;
 }
 
-int
-modifier (size)
-int *size;
+int modifier(int *size)
 {
     int is_long=0, isshort=0, issign=0, isunsign=0;
     int type = UNDECL, tsize = 0;
@@ -673,16 +668,15 @@ err:
     return 0;
 }
 
-settype(size,dimptr,ellist)
-int *size;
-dimnode **dimptr;
-elem **ellist;
+int settype(cval_t *size, dimnode **dimptr, elem **ellist)
 {
     register symnode *ptr, *tagptr;
     dimnode *dptr;
-    int offset,msize,mtype,savflg,dtype,s;
+    int offset,mtype,savflg,dtype,s;
+    cval_t msize;
     elem *eptr,*elast,*elocal;
-    int type = UNDECL, tsize = INTSIZE;
+    int type = UNDECL;
+    cval_t tsize = INTSIZE;
 
     *ellist = 0;
     if (sym==KEYWORD) {
@@ -732,7 +726,7 @@ default:
                             *ellist=tagptr->x.elems;
                             return STRUCT;
                         }
-                        *size = (int) tagptr;
+                        *size = (cval_t) tagptr;
                         return USTRUCT;
                     } else if(tagptr->type==STRUCT) multidef();
                 }
@@ -820,9 +814,7 @@ next:
 }
 
 
-declarator(ptr,dptr,bastype)
-symnode **ptr;
-dimnode **dptr;
+int declarator(symnode **ptr, dimnode **dptr, int bastype)
 {
     register dimnode *tempdim, *p, *p1;
     int dtype, savmos, count;
@@ -885,7 +877,7 @@ dimnode **dptr;
 }
 
 
-shiftin (a,b)
+int shiftin(int a, int b)
 {
     int temp;
 
@@ -898,9 +890,7 @@ shiftin (a,b)
 }
 
 
-sizeup(ptr,dimptr,size)
-register symnode *ptr;
-register dimnode *dimptr;
+int sizeup(register symnode *ptr, register dimnode *dimptr, cval_t size)
 {
     register int n,temp;
 
@@ -925,8 +915,7 @@ register dimnode *dimptr;
 }
 
 
-getsize(t,size,dptr)
-register dimnode *dptr;
+int getsize(int t, cval_t size, register dimnode *dptr)
 {
     int n;
 
@@ -945,8 +934,7 @@ register dimnode *dptr;
 }
 
 
-clear(list)
-symnode **list;
+int clear(symnode **list)
 {
     register symnode *this, *next, *p, **pp;
     char err[60];
@@ -996,14 +984,13 @@ symnode **list;
 }
 
 
-sizerr()
+int sizerr(void)
 {
     error("cannot evaluate size");
 }
 
 
-identerr()
+int identerr(void)
 {
     error("identifier missing");
 }
-

--- a/Source/Compiler/CC09/floats.c
+++ b/Source/Compiler/CC09/floats.c
@@ -8,16 +8,14 @@
 #ifdef  DOFLOATS
 
 
-dload(ptr)
-register expnode *ptr;
+int dload(register expnode *ptr)
 {
     trandexp(ptr);
     getadd(ptr);
 }
 
 
-trandexp(node)
-register expnode *node;
+int trandexp(register expnode *node)
 {
     register expnode *p;
     register int op, type;
@@ -36,22 +34,22 @@ register expnode *node;
         case UTOD:
         case ITOD:
             lddexp(node->left);
-            gen(DBLOP,op);
+            gen(DBLOP,op,0,0);
             node->op = FREG;
             break;
         case LTOD:
             lload(node->left);
-            gen(DBLOP,op);
+            gen(DBLOP,op,0,0);
             node->op = FREG;
             break;
         case DTOF:
         case FTOD:
             dload(node->left);
-            gen(DBLOP,op);
+            gen(DBLOP,op,0,0);
             node->op = FREG;
             break;
         case FCONST:
-            gen(DBLOP,FCONST,node->val.dp);
+            gen(DBLOP,FCONST,node->val.dp,0);
             node->op = XIND;
             /*  should free constant storage here  */
             node->val.dp = NULL;
@@ -65,18 +63,18 @@ register expnode *node;
         case DECBEF:
         case NEG:
             dload(node->left);
-            gen(DBLOP,op,type);
+            gen(DBLOP,op,type,0);
             node->op = XIND;
             node->val.num = 0;
             break;
         case INCAFT:
         case DECAFT:
-            gen(LOADIM,XREG,FREG);
-            gen(PUSH,XREG);
+            gen(LOADIM,XREG,FREG,0);
+            gen(PUSH,XREG,0,0);
             dload(node->left);
-            gen(DBLOP,op,type);
-            gen(DBLOP,MOVE,type);
-            gen(DBLOP,op == INCAFT ? DECAFT : INCAFT,type);
+            gen(DBLOP,op,type,0);
+            gen(DBLOP,MOVE,type,0);
+            gen(DBLOP,op == INCAFT ? DECAFT : INCAFT,type,0);
             node->op = FREG;
             break;
         case CALL:
@@ -94,16 +92,16 @@ register expnode *node;
         case TIMES:
         case DIV:
             dload(node->left);
-            gen(DBLOP,STACK);
+            gen(DBLOP,STACK,0,0);
             dload(node->right);
-            gen(DBLOP,op);
+            gen(DBLOP,op,0,0);
             node->op = FREG;
             break;
         case ASSIGN:
             dload(node->left);
-            gen(PUSH,XREG);
+            gen(PUSH,XREG,0,0);
             dload(node->right);
-            gen(DBLOP,MOVE,type);
+            gen(DBLOP,MOVE,type,0);
             node->op = XIND;
             node->val.num = 0;
             break;
@@ -112,17 +110,17 @@ register expnode *node;
                 p = node->left;
                 if (type == FLOAT) {
                     dload(p->left);
-                    gen(PUSH,XREG);
-                    gen(DBLOP,FTOD);
+                    gen(PUSH,XREG,0,0);
+                    gen(DBLOP,FTOD,0,0);
                 } else {
                     dload(p);
-                    gen(PUSH,XREG);
+                    gen(PUSH,XREG,0,0);
                 }
                 node->op = op - (ASSPLUS - PLUS);
                 p->op = XIND;
                 trandexp(node);
-                if (type == FLOAT) gen(DBLOP,DTOF);
-                gen(DBLOP,MOVE,type);
+                if (type == FLOAT) gen(DBLOP,DTOF,0,0);
+                gen(DBLOP,MOVE,type,0);
                 node->op = XIND;
                 node->val.num = 0;
                 break;

--- a/Source/Compiler/CC09/fltconv.c
+++ b/Source/Compiler/CC09/fltconv.c
@@ -49,9 +49,7 @@
 #define IEEE_EXPN_MASK	(0xFFFLL << IEEE_MANT_BITS)
 #define IEEE_EXPN_BIAS	1022
 
-double
-dadjust (n)
-double	n;
+double dadjust(double n)
 {
 	union {
 		double		d;

--- a/Source/Compiler/CC09/get.c
+++ b/Source/Compiler/CC09/get.c
@@ -23,7 +23,7 @@ static long soffset;
 */
 
 
-preinit()
+int preinit(void)
 {
         lptr=line;
         *line='\0';
@@ -31,13 +31,13 @@ preinit()
 }
 
 
-blanks()
+int blanks(void)
 {
         while(cc==' ' || cc == '\t') getch();
 }
 
 
-getch()
+int getch(void)
 {
         if(cc= *lptr++)
                 ;
@@ -46,12 +46,12 @@ getch()
 }
 
 
-getlin()
+int getlin(void)
 {
         int lno, n, x;
         static char temp[LINESIZE];
         static direct int lineflg;
-        char *cgets();
+        char *cgets(void);
 
         if(lineflg == 0) {
                 lineflg = 1;
@@ -97,8 +97,11 @@ getlin()
 #ifdef SPLIT
                                 passthru();
 #endif
-                                fprintf(code," psect %s,0,0,%d,0,0\n",
-                                             temp,atoi(line));
+                                if (lwflag)
+                                        fprintf(code," SECTION code\n");
+                                else
+                                        fprintf(code," psect %s,0,0,%d,0,0\n",
+                                                     temp,atoi(line));
 #ifdef SPLIT
                                 passthru();
 #endif
@@ -158,8 +161,7 @@ getlin()
 
 /* this atoi is smaller than the library version */
 #ifdef _OS9
-atoi(s)
-register char *s;
+int atoi(register char *s)
 {
         int n = 0;
 
@@ -171,8 +173,7 @@ register char *s;
 #endif
 
 
-char *
-cgets()                 /* Function to input a line of source.
+char *cgets(void)       /* Function to input a line of source.
                          * Returns a pointer to the start of the line
                          * if all is well.
                          * Returns NULL on end of file.
@@ -216,4 +217,3 @@ cgets()                 /* Function to input a line of source.
         symptr = line;
         fatal("input line too long");   /* NO RETURN ! */
 }
-

--- a/Source/Compiler/CC09/inits.c
+++ b/Source/Compiler/CC09/inits.c
@@ -7,16 +7,15 @@
 */
 
 #include "cj.h"
-static ilist();
-static defobject();
-static datdef();
-static iskip();
+static int ilist(int, symnode *, dimnode *, int);
+static int defobject(int);
+static int datdef(cval_t, int);
+static int iskip(void);
 extern direct int stringlen;
 direct int datstring;
 
 
-initialise(ptr,tsc,type)
-register symnode *ptr;
+int initialise(register symnode *ptr, int tsc, int type)
 {
     register char *p;
     register dimnode *dimp;
@@ -77,10 +76,7 @@ out:
 
 #define INFINITY (-1)
 
-static 
-ilist(type,ptr,list,level)
-register symnode *ptr;
-register dimnode *list;
+static int ilist(int type, register symnode *ptr, register dimnode *list, int level)
 {
     register dimnode *newlist;
     int flag,t,i;
@@ -145,15 +141,14 @@ out:
 }
 
 
-zero(n)
+int zero(int n)
 {
-    ot("rzb ");
+    ot(lwflag ? "rmb " : "rzb ");
     od(n);
     nl();
 }
 
-static defobject(type)
-register int type;
+static int defobject(register int type)
 {
     register expnode *p, *p2;
     int addon, done, t;
@@ -239,9 +234,7 @@ finish:
 }
 
 
-static 
-datdef(p,type)
-register int *p;
+static int datdef(cval_t p, int type)
 {
     register int size;
 	int flt = 0;
@@ -250,7 +243,7 @@ register int *p;
         case CHAR:
         case UCHAR:
             defbyte();
-            od((int)p & 0xff);
+            od(p & 0xff);
             nl();
             return;
         case INT:
@@ -263,19 +256,18 @@ register int *p;
         case DOUBLE:    size = (DOUBLESIZE/2);  flt = 1; break;
 #endif
     }
-    defcon(p,size,flt);
+    defcon((int *)p,size,flt);
 }
 
 
-initerr()
+int initerr(void)
 {
     error("cannot initialize");
     iskip();
 }
 
 
-static
-iskip()
+static int iskip(void)
 {
     for (;;)
         switch (sym) {
@@ -287,4 +279,3 @@ iskip()
                 getsym();
         }
 }
-

--- a/Source/Compiler/CC09/lex.c
+++ b/Source/Compiler/CC09/lex.c
@@ -494,6 +494,7 @@ int number(int type, register numptrs np)
     long i;
     double n;
     int exp, esign, digcount = 0;
+    int long_suffix, unsigned_suffix;
     register char *cp;
 
     i = 0;
@@ -521,8 +522,13 @@ int number(int type, register numptrs np)
                 getch();
             }
 
-        if (cc == 'L' || cc == 'l') {   /* explicit long */
+        long_suffix = unsigned_suffix = 0;
+        while (cc == 'L' || cc == 'l' || cc == 'U' || cc == 'u') {
+            if (cc == 'L' || cc == 'l') long_suffix = 1;
+            else unsigned_suffix = 1;
             getch();
+        }
+        if (long_suffix) {   /* explicit long */
             goto retlong;
         }
 
@@ -594,8 +600,13 @@ fraction:
 #ifdef _LIL_END
     if (*(int64_t *)&n > __INT32_MAX__) return 0;
     *np.lp = *((long*)&n);
-    if (cc=='l' || cc=='L') {       /* explicitly long */
+    long_suffix = unsigned_suffix = 0;
+    while (cc == 'L' || cc == 'l' || cc == 'U' || cc == 'u') {
+        if (cc == 'L' || cc == 'l') long_suffix = 1;
+        else unsigned_suffix = 1;
         getch();
+    }
+    if (long_suffix) {       /* explicitly long */
 longint:
 # ifdef DEBUG
         fprintf(stderr,"number: n=%08lX\n",*((long*)&n));
@@ -608,8 +619,13 @@ longint:
     }
 #else /* big endian */
     if (*((long*)&n)) return 0;     /*  overflow  */
-    if (cc=='l' || cc=='L') {   /* explicitly long */
+    long_suffix = unsigned_suffix = 0;
+    while (cc == 'L' || cc == 'l' || cc == 'U' || cc == 'u') {
+        if (cc == 'L' || cc == 'l') long_suffix = 1;
+        else unsigned_suffix = 1;
         getch();
+    }
+    if (long_suffix) {   /* explicitly long */
 longint:
 # ifdef DEBUG
 #  ifdef MWOS

--- a/Source/Compiler/CC09/lex.c
+++ b/Source/Compiler/CC09/lex.c
@@ -331,7 +331,6 @@ int lexinit(void)
      install("char",CHAR);
      install("short",SHORT);
      install("long",LONG);
-     install("void",INT);
      mosflg=1; /* These keywords may appear inside struct defs */
      install("int",INT);
      install("char",CHAR);
@@ -339,7 +338,6 @@ int lexinit(void)
      install("long",LONG);
      install("signed", SIGN);
      install("unsigned",UNSIGN);
-     install("void",INT);
      install("const",QUAL);
      install("volatile",QUAL);
 #ifdef DOFLOATS
@@ -371,10 +369,18 @@ int lexinit(void)
 }
 
 
+static int keyword_prefix(char *name)
+{
+    return strcmp(name, "continue") == 0
+            || strcmp(name, "register") == 0
+            || strcmp(name, "unsigned") == 0
+            || strcmp(name, "volatile") == 0;
+}
+
 int getword(char *name)
 {
     char            str[NAMESIZE+1];
-    int             count;
+    int             count, extra;
     register char   *p = str;
 
     for (count = 1; an (cc) && count <= NAMESIZE; ++count) {
@@ -382,11 +388,13 @@ int getword(char *name)
         getch ();
     }
     *p = '\0';
+    extra = an(cc) ? cc : 0;
 
     if (!str[1]) {  /* name is 1 char */
         *name++ = UNIQUE;   /* prepend __ if it could be a register name */
         *name++ = UNIQUE;
     }
+    if (extra && keyword_prefix(str)) str[NAMESIZE-1] = extra;
     strcpy (name, str);
 
     while (an (cc)) getch ();

--- a/Source/Compiler/CC09/lex.c
+++ b/Source/Compiler/CC09/lex.c
@@ -16,7 +16,14 @@
 
 #include "cj.h"
 
-static double normaliz();
+#ifdef _LIL_END
+static double normaliz(int64_t *);
+int addin(int64_t *, char);
+#else
+static double normaliz(long *);
+#endif
+int isoct(char);
+int ishex(char);
 
 #define     isdigit(c)  (chartab[c]==DIGIT)
 
@@ -34,11 +41,11 @@ extern double atoftbl[];
 #endif
 direct int stringlen;
 
-extern symnode *lookup();
-extern char *grab();
+extern symnode *lookup(char []);
+extern char *grab(int);
 
 
-getsym()
+int getsym(void)
 {
     register symnode *ptr;
     register int numtype;
@@ -75,7 +82,7 @@ getsym()
                 }
             } else {
                 sym = NAME;
-                symval = (int) ptr;
+                symval = (cval_t) ptr;
             }
             break;
         case DIGIT:
@@ -98,7 +105,7 @@ donum:
                 case LONG:
                     longp = (long *) grab(sizeof(long));
                     *longp = *np.lp;
-                    symval = (int) longp;
+                    symval = (cval_t) longp;
 #ifdef DEBUG
                     fprintf(stderr,"getsym: symval=%04X, *longp=%08lX\n",
                             symval,*longp);
@@ -109,7 +116,7 @@ donum:
                 case DOUBLE:
                     dblp = (double *) grab(sizeof(double));
                     *dblp = *np.dp;
-                    symval = (int) dblp;
+                    symval = (cval_t) dblp;
                     sym = FCONST;
                     break;
 #endif
@@ -311,7 +318,7 @@ char valtab[] = {
 /*                                  OR              COMPL */
 };
 
-lexinit()
+int lexinit(void)
 {
 #ifdef  DOFLOATS
      install("double",DOUBLE);
@@ -358,10 +365,9 @@ lexinit()
 }
 
 
-getword (name)
-char *name;
+int getword(char *name)
 {
-    char            str[NAMESIZE];
+    char            str[NAMESIZE+1];
     int             count;
     register char   *p = str;
 
@@ -381,17 +387,14 @@ char *name;
 }
 
 
-an(c)
-int c;
+int an(int c)
 {
     return (chartab[c]==LETTER || chartab[c]==DIGIT);
 }
 
 direct  symnode *freesym;       /* list of free symbol table entries */
 
-symnode *
-lookup(name)
-char name[];
+symnode *lookup(char name[])
 {
     /* return a pointer to a symbol table entry for 'name'  */
     /* if one is not found create one                       */
@@ -431,9 +434,7 @@ char name[];
 }
 
 
-install(word,typ)
-char *word;
-int typ;
+int install(char *word, int typ)
 {
         /* put a keyword in the symbol table */
         register symnode *cptr;
@@ -450,8 +451,7 @@ int typ;
 }
 
 
-hash(word)
-register char *word;
+int hash(register char *word)
 {
     register int n = 0, c;
 
@@ -461,9 +461,7 @@ register char *word;
 }
 
 
-char *
-grab(size)
-int size;
+char * grab(int size)
 {
     char *oldptr;
 
@@ -477,11 +475,10 @@ int size;
 
 
 #ifdef  DOFLOATS
-number(type,np)
-register numptrs np;
+int number(int type, register numptrs np)
 {
     long i;
-    double n, scale(), normaliz();
+    double n;
     int exp, esign, digcount = 0;
     register char *cp;
 
@@ -618,8 +615,7 @@ longint:
 }
 
 #else   /* !DOFLOATS */
-number(np)
-register long *np;
+int number(register long *np)
 {
        long n;
        register char *cp;
@@ -685,7 +681,7 @@ register long *np;
 #endif  /* !DOFLOATS */
 
 
-pstr()
+int pstr(void)
 {
         getch();
 
@@ -706,7 +702,7 @@ pstr()
 static direct FILE *sfile;
 extern direct int datstring;
 
-qstr()
+int qstr(void)
 {
         switch(datstring) {
                 case 0:
@@ -774,8 +770,7 @@ fillstr:
 }
 
 
-oc(c)
-int c;
+int oc(int c)
 {
 #ifdef  SPLIT
         if(c == '\0' || c == '\\')
@@ -807,16 +802,16 @@ int c;
 }
 
 
-oz(n)
+int oz(int n)
 {
 #ifdef SPLIT
      passthru();
 #endif
-     fprintf(sfile," rzb %d\n",n);
+     fprintf(sfile,lwflag ? " rmb %d\n" : " rzb %d\n",n);
 }
 
 
-dobslash()
+int dobslash(void)
 {
         register int c,n;
 
@@ -865,40 +860,34 @@ dobslash()
 }
 
 
-isoct(c)
-char c;
+int isoct(char c)
 {
         return (c<='7' && c>='0');
 }
 
 
-ishex(c)
-char c;
+int ishex(char c)
 {
         return ( isdigit(c) ||  ((c &=0x5f) >='A' && c<='F')) ? c : 0;
 }
 
 
-static double
-normaliz(n)
 #ifdef _LIL_END
-int64_t *n;
+static double normaliz(int64_t *n)
 {
     return (double)(*n);
 }
 #else /* big endian */
-long n[];
+static double normaliz(long n[])
 {
     return n[0] * 4294967296. + n[1];
 }
 #endif
 
 #if defined(MWOS) && defined(_BIG_END)
-static numshf(n);
+static int numshf(char *);
 
-addin(n,c)
-register char n[];
-char c;
+int addin(register char n[], char c)
 {
     register int i,x;
     char ntemp[8];
@@ -916,9 +905,7 @@ char c;
 }
 
 
-static
-numshf(n)
-register char n[];
+static int numshf(register char n[])
 {
     register int i, x = 0;
 
@@ -931,9 +918,7 @@ register char n[];
 
 #else   /* portable but needs long long integers */
 
-addin(n,c)
-int64_t *n;
-char c;
+int addin(int64_t *n, char c)
 {
     int64_t val = *n;
 

--- a/Source/Compiler/CC09/lex.c
+++ b/Source/Compiler/CC09/lex.c
@@ -331,6 +331,7 @@ int lexinit(void)
      install("char",CHAR);
      install("short",SHORT);
      install("long",LONG);
+     install("void",INT);
      mosflg=1; /* These keywords may appear inside struct defs */
      install("int",INT);
      install("char",CHAR);
@@ -338,6 +339,9 @@ int lexinit(void)
      install("long",LONG);
      install("signed", SIGN);
      install("unsigned",UNSIGN);
+     install("void",INT);
+     install("const",QUAL);
+     install("volatile",QUAL);
 #ifdef DOFLOATS
      install("float",FLOAT);
 #endif
@@ -362,6 +366,8 @@ int lexinit(void)
      install("union",UNION);
      install("signed", SIGN);
      install("unsigned",UNSIGN);
+     install("const",QUAL);
+     install("volatile",QUAL);
 }
 
 

--- a/Source/Compiler/CC09/local.c
+++ b/Source/Compiler/CC09/local.c
@@ -22,16 +22,20 @@ static direct unsigned stklab;       /* label for stack check equ value */
 
 
 
-epilogue()
+int epilogue(void)
 {
      dumpstrings();
      endsect();
-     if(errcount)
-          ol("fail source errors");
+     if(errcount) {
+          if (lwflag)
+               ol("ERROR source errors");
+          else
+               ol("fail source errors");
+     }
 }
 
 
-locstat(l,size,area)
+void locstat(int l, int size, int area)
 {
      vsect(area);
      olbl(l);
@@ -40,7 +44,7 @@ locstat(l,size,area)
 }
 
 
-defglob(ptr,size,area)
+void defglob(symnode *ptr, int size, int area)
 {
      vsect(area);
      defvar(ptr,size,GBLB);
@@ -48,7 +52,7 @@ defglob(ptr,size,area)
 }
 
 
-extstat(ptr,size,area)
+void extstat(symnode *ptr, int size, int area)
 {
      vsect(area);
      defvar(ptr,size,LCLB);
@@ -56,17 +60,14 @@ extstat(ptr,size,area)
 }
 
 
-defvar(ptr,size,scope)
-symnode *ptr;
-char scope;
+void defvar(symnode *ptr, int size, int scope)
 {
      fprintf(code,"%.8s%c rmb %d\n",ptr->sname,scope,size);
 }
 
 
 #ifdef PROF
-profname(name,lab)
-char *name;
+void profname(char *name, int lab)
 {
      olbl(lab);
      fprintf(code," fcc \"%.8s\"\n fcb 0\n",name);
@@ -76,20 +77,16 @@ char *name;
 
 #ifdef REGPARMS
 # ifdef PROF
-startfunc(name,flag,paramreg,lab)
+void startfunc(register char *name, int flag, int paramreg, int lab)
 # else
-startfunc(name,flag,paramreg)
+void startfunc(register char *name, int flag, int paramreg)
 # endif
 #else
 # ifdef PROF
-startfunc(name,flag,lab)
+void startfunc(register char *name, int flag, int lab)
 # else
-startfunc(name,flag)
+void startfunc(register char *name, int flag)
 # endif
-#endif
-register char *name;
-#ifdef REGPARMS
-int paramreg;
 #endif
 {
 #ifdef FUNCNAME
@@ -132,7 +129,7 @@ int paramreg;
 }
 
 
-endfunc()
+void endfunc(void)
 {
         /* generate stack reservation value */
      if(!sflag)
@@ -140,38 +137,44 @@ endfunc()
 }
 
 
-defbyte()
+void defbyte(void)
 {
         ot("fcb ");
 }
 
 
-defword()
+void defword(void)
 {
         ot("fdb ");
 }
 
 
-comment()
+void comment(void)
 {
         os("* ");
 }
 
 
-vsect(area)
+void vsect(int area)
 {
-     ol(area ? "vsect dp" : "vsect");
+     if (lwflag)
+          ol("SECTION data");
+     else
+          ol(area ? "vsect dp" : "vsect");
 }
 
 
-endsect()
+void endsect(void)
 {
-     ol("endsect");
+     if (lwflag)
+          ol("ENDSECT\n SECTION code");
+     else
+          ol("endsect");
 }
 
 
 /*
-dumpstrings()
+int dumpstrings(void)
 {
      register int c;
 
@@ -186,7 +189,7 @@ dumpstrings()
      }
 }
 */
-dumpstrings()
+int dumpstrings(void)
 {
      register int c;
 
@@ -201,7 +204,7 @@ dumpstrings()
 }
 
 
-tidy()
+int tidy(void)
 {
      int err = errno ? errno : 1;
 
@@ -211,4 +214,3 @@ tidy()
      }
      _exit(err);
 }
-

--- a/Source/Compiler/CC09/longs.c
+++ b/Source/Compiler/CC09/longs.c
@@ -14,16 +14,14 @@
 #define swap(x,y)      {expnode *t;t=x;x=y;y=t;}
 
 
-lload(ptr)
-expnode *ptr;
+int lload(expnode *ptr)
 {
     tranlexp(ptr);
     getadd(ptr);
 }
 
 
-tranlexp(node)
-register expnode *node;
+int tranlexp(register expnode *node)
 {
     register expnode *p;
     register int op,s;
@@ -49,7 +47,7 @@ register expnode *node;
                 case YIND:
                 case UIND:
                     if (node->val.num) {
-                        gen(LEAX,NODE,node);
+                        gen(LEAX,NODE,node,0);
                         node->op = XIND;
                         node->val.num = 0;
                     }
@@ -57,19 +55,19 @@ register expnode *node;
             break;
         case UTOL:
             lddexp(node->left);
-            gen(LONGOP,UTOL);
+            gen(LONGOP,UTOL,0,0);
             node->op=FREG;
             break;
 #ifdef  DOFLOATS
         case DTOL:
             dload(node->left);
-            gen(DBLOP,DTOL,node->left);
+            gen(DBLOP,DTOL,node->left,0);
             node->op=FREG;
             break;
 #endif
         case ITOL:
             lddexp(node->left);
-            gen(LONGOP,ITOL);
+            gen(LONGOP,ITOL,0,0);
             node->op=FREG;
             break;
         case LCONST:
@@ -77,7 +75,7 @@ register expnode *node;
             fprintf(stderr,"tranlexp: *(node->val.lp=%04X)=%08lX\n",
                     node->val.lp,*node->val.lp);
 #endif
-            gen(LONGOP,LCONST,node->val.lp);
+            gen(LONGOP,LCONST,node->val.lp,0);
             /*  should free constant storage here  */
             node->val.lp = NULL;
             node->op = XIND;
@@ -93,18 +91,18 @@ register expnode *node;
         case COMPL:
         case NEG:
             lload(node->left);
-            gen(LONGOP,op);
+            gen(LONGOP,op,0,0);
             node->op = XIND;
             node->val.num = 0;
             break;
         case INCAFT:
         case DECAFT:
             gen(LOADIM,XREG,FREG,0);
-            gen(PUSH,XREG);
+            gen(PUSH,XREG,0,0);
             lload(node->left);
-            gen(LONGOP,op);
-            gen(LONGOP,MOVE);
-            gen(LONGOP,op==INCAFT ? DECAFT : INCAFT);
+            gen(LONGOP,op,0,0);
+            gen(LONGOP,MOVE,0,0);
+            gen(LONGOP,op==INCAFT ? DECAFT : INCAFT,0,0);
             node->op=FREG;
             break;
         case CALL:
@@ -151,10 +149,10 @@ register expnode *node;
             if(p->op==LCONST) pushcon(p);
             else {
                 lload(p);
-                gen(LONGOP,STACK);
+                gen(LONGOP,STACK,0,0);
             }
             lload(node->right);
-            gen(LONGOP,op);
+            gen(LONGOP,op,0,0);
             node->op=FREG;
             break;
 
@@ -163,17 +161,17 @@ shifts:
         case SHR:
         case USHR:
             lload(node->left);
-            gen(PUSH,XREG);
+            gen(PUSH,XREG,0,0);
             lddexp(node->right);
-            gen(LONGOP,op);
+            gen(LONGOP,op,0,0);
             node->op=FREG;
             break;
 
         case ASSIGN:
             lload(node->left);
-            gen(PUSH,XREG);
+            gen(PUSH,XREG,0,0);
             lload(node->right);
-            gen(LONGOP,MOVE);
+            gen(LONGOP,MOVE,0,0);
             node->op = XIND;
             node->val.num = 0;
             break;
@@ -188,11 +186,11 @@ shifts:
         default:
             if (op >= ASSPLUS) {
                 lload(p=node->left);
-                gen(PUSH,XREG);
+                gen(PUSH,XREG,0,0);
                 node->op=op-(ASSPLUS-PLUS);
                 p->op=XIND;
                 tranlexp(node);
-                gen(LONGOP,MOVE);
+                gen(LONGOP,MOVE,0,0);
                 node->op = XIND;
                 node->val.num = 0;
                 break;
@@ -206,8 +204,7 @@ shifts:
 }
 
 
-getadd(ptr)
-register expnode *ptr;
+int getadd(register expnode *ptr)
 {
     switch(ptr->op) {
         case NAME:
@@ -218,7 +215,7 @@ register expnode *ptr;
             break;
         case YIND:
         case UIND:
-            gen(LEAX,NODE,ptr);
+            gen(LEAX,NODE,ptr,0);
 #ifdef REGCONTS
             setxreg(ptr);
 #endif
@@ -227,20 +224,19 @@ register expnode *ptr;
 }
 
 
-pushcon(p)
-register expnode *p;
+int pushcon(register expnode *p)
 {
     register long *p1;
 
     if ((p1 = p->val.lp) && *p1) {
         gen(LOAD,DREG,CONST,(int) *p1);
-        gen(PUSH,DREG);
+        gen(PUSH,DREG,0,0);
         gen(LOAD,DREG,CONST,(int) (*p1 >> 16));
-        gen(PUSH,DREG);
+        gen(PUSH,DREG,0,0);
     } else {
         gen(LOAD,DREG,CONST,0);
-        gen(PUSH,DREG);
-        gen(PUSH,DREG);
+        gen(PUSH,DREG,0,0);
+        gen(PUSH,DREG,0,0);
     }
     if (p1) {
         /*  should free constant storage here  */

--- a/Source/Compiler/CC09/misc.c
+++ b/Source/Compiler/CC09/misc.c
@@ -12,8 +12,7 @@
 
 /* to push down an outer block declaration
  */
-pushdown(sptr)
-register symnode *sptr;
+int pushdown(register symnode *sptr)
 {
     register symnode *nptr;
 
@@ -29,8 +28,7 @@ register symnode *sptr;
 
 /* to recover outer block declaration
  */
-pullup(sptr)
-register symnode *sptr;
+int pullup(register symnode *sptr)
 {
     register symnode *nptr;
 
@@ -44,16 +42,13 @@ register symnode *sptr;
 
 /* byte move by count
  */
-move(p1,p2,count)
-register char *p1, *p2;
-int count;
+int move(register char *p1, register char *p2, int count)
 {
     while (count--) *p2++ = *p1++;
 }
 
 
-fatal(errstr)
-char *errstr;
+int fatal(char *errstr)
 {
     error(errstr);
     fflush(stderr); /* because 'tidy()' uses '_exit()' i.e. no flush */
@@ -61,29 +56,25 @@ char *errstr;
 }
 
 
-multidef()
+int multidef(void)
 {
     error("multiple definition");
 }
 
 
-error(s)
-char s[];
+int error(char s[])
 {
     doerr(symptr-line,s,symline);
 }
 
 
-warn(s)
-char s[];
+int warn(char s[])
 {
     dowarn(symptr-line,s,symline);
 }
 
 
-comperr(node,errstr)
-register expnode *node;
-char *errstr;
+int comperr(register expnode *node, char *errstr)
 {
     char newstr[50];
 
@@ -93,17 +84,13 @@ char *errstr;
 }
 
 
-terror(node,errstr)
-register expnode *node;
-char *errstr;
+int terror(register expnode *node, char *errstr)
 {
     doerr(node->pnt - line,errstr,node->lno);
 }
 
 
-dowarn(n,wstr,lno)
-register int n;
-char wstr[];
+int dowarn(register int n, char wstr[], int lno)
 {
     eprintf("%s:%d: *** warning: %s ***\n", filename, lno, wstr);
     if (lno == lineno) {
@@ -118,9 +105,7 @@ dopoint:
 }
 
 
-doerr(n,errstr,lno)
-register int n;
-char errstr[];
+int doerr(register int n, char errstr[], int lno)
 {
     eprintf("%s:%d: *** %s ***\n", filename, lno, errstr);
     if (lno == lineno) {
@@ -140,30 +125,30 @@ dopoint:
 }
 
 
-eprintf(msg,s1,s2,s3,s4)
-char *msg;
+void eprintf(char *msg, ...)
 {
-    fprintf(stderr,msg,s1,s2,s3,s4);
+    va_list ap;
+
+    va_start(ap,msg);
+    vfprintf(stderr,msg,ap);
+    va_end(ap);
 }
 
 
-eputs(s)
-char *s;
+void eputs(char *s)
 {
     fputs(s,stderr);
     eputchar('\n');
 }
 
 
-eputchar(c)
-char c;
+void eputchar(int c)
 {
     putc(c,stderr);
 }
 
 
-reltree(tree)
-register expnode *tree;
+int reltree(register expnode *tree)
 {
     if (tree) {
 #ifdef DEBUG
@@ -180,8 +165,7 @@ register expnode *tree;
 }
 
 
-release(node)
-register expnode *node;
+int release(register expnode *node)
 {
     if(node) {
         node->left=freenode;
@@ -190,14 +174,13 @@ register expnode *node;
 }
 
 
-nodecopy(n1,n2)
-char *n1,*n2;
+int nodecopy(char *n1, char *n2)
 {
     move(n1,n2,NODESIZE);
 }
 
 
-istype()
+int istype(void)
 {
     if (sym == KEYWORD)
         switch (symval) {
@@ -222,7 +205,7 @@ istype()
 }
 
 
-issclass()
+int issclass(void)
 {
     if(sym==KEYWORD) switch(symval) {
         case EXTERN:
@@ -237,34 +220,31 @@ issclass()
 }
 
 
-decref(t)
+int decref(int t)
 {
     return ((t >> 2) & (~BASICT)) + btype(t) ;
 }
 
 
-incref(t)
+int incref(int t)
 {
     return ((t & (~BASICT)) << 2 ) + POINTER + btype(t) ;
 }
 
 
-isbin(op)
-register int op;
+int isbin(register int op)
 {
     return (op>=UMOD && op<=UGT);
 }
 
 
-dimnode *
-dimwalk(dptr)
-register dimnode *dptr;
+dimnode * dimwalk(register dimnode *dptr)
 {
     return dptr ? dptr->dptr : 0;
 }
 
 
-need(key)
+int need(int key)
 {
     static char ptr[] = "x expected";
     register int i;
@@ -294,14 +274,14 @@ need(key)
 }
 
 
-junk()
+int junk(void)
 {
     while (sym != SEMICOL && sym != RBRACE && sym != EOF) getsym();
 }
 
 
 #ifdef PTREE
-getkeys()
+int getkeys(void)
 {
     char kname[20];
     register char *p;
@@ -325,9 +305,7 @@ getkeys()
     fclose(in1);
 }
 
-prtree(node,title)
-expnode *node;
-char *title;
+int prtree(expnode *node, char *title)
 {
     if (dflag) {
         fflush(stdout);
@@ -337,8 +315,7 @@ char *title;
 }
 
 
-ptree(node)
-register expnode *node;
+int ptree(register expnode *node)
 {
     if (node) {
         pnode(node);
@@ -348,8 +325,7 @@ register expnode *node;
 }
 
 
-pnode(node)
-register expnode *node;
+int pnode(register expnode *node)
 {
     int op,val,i;
 

--- a/Source/Compiler/CC09/misc.c
+++ b/Source/Compiler/CC09/misc.c
@@ -190,6 +190,7 @@ int istype(void)
             case SIGN:
             case SHORT:
             case LONG:
+            case QUAL:
             case STRUCT:
             case UNION:
 #ifdef  DOFLOATS

--- a/Source/Compiler/CC09/misc.c
+++ b/Source/Compiler/CC09/misc.c
@@ -200,6 +200,8 @@ int istype(void)
                 return 1;
         }
     else if (sym == NAME) {
+        if (strncmp(((symnode *)symval)->sname, "void", NAMESIZE) == 0)
+            return 1;
         if (((symnode *)symval)->storage == TYPEDEF) return 1;
     }
     return 0;

--- a/Source/Compiler/CC09/optim.c
+++ b/Source/Compiler/CC09/optim.c
@@ -10,9 +10,7 @@
 #define swap(type,x,y)  {type t;t = x;x = y;y = t;}
 
 
-expnode *
-optim(tree)
-register expnode *tree;
+expnode * optim(register expnode *tree)
 {
     register expnode *lhs,*rhs,*tptr;
     int op;
@@ -68,9 +66,7 @@ exit:   ;
 }
 
 
-expnode *
-fold(tree)
-register expnode *tree;
+expnode * fold(register expnode *tree)
 {
     register expnode *lhs,*rhs,*ptr;
     register int op,opl,opr;
@@ -219,8 +215,7 @@ doop:               tree->op=CONST;
 }
 
 
-isleaf(node)
-register expnode *node;
+int isleaf(register expnode *node)
 {
     if (node)
         switch (node->op) {
@@ -241,7 +236,7 @@ register expnode *node;
 }
 
 
-diverr()
+int diverr(void)
 {
     error("divide by zero");
 }
@@ -253,9 +248,7 @@ diverr()
  * fills in various node fields according to types and operators.
  * tree should not present any problems to the translator after this.
  */
-expnode *
-chtype(node)
-expnode *node;
+expnode * chtype(expnode *node)
 {
     register expnode *lhs,*rhs,*eptr;
     register symnode *sptr;
@@ -342,8 +335,8 @@ expnode *node;
             else t = cvt(lhs,t);
             dptr = node->dimptr;
             size = node->size;
-            release(node);
-            node = lhs;
+            nodecopy(lhs,node);
+            release(lhs);
             break;
 
         case AMPER:
@@ -683,8 +676,7 @@ asserr:
 }
 
 
-chknull(node)
-register expnode *node;
+int chknull(register expnode *node)
 {
     if (node->op != CONST || node->val.num != 0) {
         terror(node,"should be NULL");
@@ -694,8 +686,7 @@ register expnode *node;
 }
 
 
-usual(node)
-register expnode *node;
+int usual(register expnode *node)
 {
     register int t;
 
@@ -718,8 +709,7 @@ register expnode *node;
 }
 
 
-cvt(node,t)
-register expnode *node;
+int cvt(register expnode *node, int t)
 {
     expnode *ptr;
     DBLETYPE *dblptr;
@@ -911,8 +901,7 @@ fixint:
 }
 
 
-tymatch(lhs,rhs)
-register expnode *lhs,*rhs;
+int tymatch(register expnode *lhs, register expnode *rhs)
 {
     register int tl,tr;
 
@@ -933,9 +922,7 @@ register expnode *lhs,*rhs;
 }
 
 
-expnode *
-fixup(size,t,dptr,rhs)
-register expnode *dptr,*rhs;
+expnode *fixup(int size, int t, register expnode *dptr, register expnode *rhs)
 {
     register expnode *ptr;
 
@@ -952,8 +939,7 @@ register expnode *dptr,*rhs;
 }
 
 
-needlval(node,flag)
-register expnode *node;
+int needlval(register expnode *node, int flag)
 {
     int op;
 
@@ -976,8 +962,7 @@ register expnode *node;
 }
 
 
-chkdecl(node)
-register expnode *node;
+int chkdecl(register expnode *node)
 {
     if (node->op == NAME && node->type == UNDECL) {
         terror(node,"undeclared variable");
@@ -986,9 +971,7 @@ register expnode *node;
 }
 
 
-needmos(node,t,mosar)
-register expnode *node;
-int *t,*mosar;
+int needmos(register expnode *node, int *t, int *mosar)
 {
     register expnode *eptr;
     register symnode *sptr;
@@ -1022,8 +1005,7 @@ err:
 }
 
 
-chkstrct(node)
-register expnode *node;
+int chkstrct(register expnode *node)
 {
     if ((node->type) == STRUCT || node->type == UNION) {
         terror(node,"structure or union inappropriate");
@@ -1033,8 +1015,7 @@ register expnode *node;
 }
 
 
-makedummy(node)
-register expnode *node;
+int makedummy(register expnode *node)
 {
     move(&sdummy,node,6);
     node->sux = 1;
@@ -1046,7 +1027,7 @@ register expnode *node;
 }
 
 
-isint(t)
+int isint(int t)
 {
     switch(t){
         case INT:
@@ -1061,7 +1042,7 @@ isint(t)
 }
 
 
-integerr(node)
+int integerr(expnode *node)
 {
     terror(node,"must be integral");
 }

--- a/Source/Compiler/CC09/printf.c
+++ b/Source/Compiler/CC09/printf.c
@@ -12,13 +12,13 @@
 #define direct
 #endif
 
-static _dofp(fmt,args);
-static itoa(n);
-static xtoa(n);
-static utoa(s,n);
-static putstr(s,len);
-static putstr1(s,len,len1);
-static putch(c);
+static int _dofp(char *fmt, int *args);
+static char *itoa(int n);
+static int xtoa(unsigned n);
+static char *utoa(char *s, int n);
+static int putstr(char *s, int len);
+static int putstr1(char *s, int len, int len1);
+static int putch(int c);
 
 #define DIGIT  107
 
@@ -37,9 +37,7 @@ static direct int leftflag,pad,flag;
 #define string  2
 
 #ifndef __unix__
-printf(fmt,args)
-char *fmt;
-int args;
+int printf(char *fmt, int args)
 {
     pointer=stdout;
     flag = file;
@@ -47,10 +45,7 @@ int args;
 }
 
 
-fprintf(f,fmt,args)
-char *fmt;
-FILE *f;
-int args;
+int fprintf(FILE *f, char *fmt, int args)
 {
     pointer=f;
     flag = file;
@@ -58,8 +53,7 @@ int args;
 }
 
 
-sprintf(s,fmt,args)
-char *s,*fmt;
+int sprintf(char *s, char *fmt, int args)
 {
     pointer = s;
     flag = string;
@@ -68,10 +62,7 @@ char *s,*fmt;
 }
 
 
-static 
-_dofp(fmt,args)
-register char *fmt;
-register int *args;
+static int _dofp(register char *fmt, register int *args)
 {
     char *ptr,c;
     int digits1,point,digits2;
@@ -134,8 +125,7 @@ register int *args;
 }
 
 
-static
-itoa(n)
+static char *itoa(int n)
 {
     char *p;
 
@@ -157,9 +147,7 @@ static int tens[] = {
 
 static direct int *tensend = &tens[4];
 
-static
-utoa(s,n)
-char *s;
+static char *utoa(char *s, int n)
 {
     register char *p;
     register int *ip;
@@ -190,9 +178,7 @@ char *s;
 }
 
 
-static
-xtoa(n)
-unsigned n;
+static int xtoa(unsigned n)
 {
     register char *p,*s1;
     int n1;
@@ -211,10 +197,7 @@ unsigned n;
 }
 
 
-static
-putstr(s,len)
-register int len;
-register char *s;
+static int putstr(register char *s, register int len)
 {
     int c;
 
@@ -228,10 +211,7 @@ register char *s;
 }
 
 
-static
-putstr1(s,len,len1)
-register char *s;
-register int len;
+static int putstr1(register char *s, register int len, int len1)
 {
     int padding = len1 - len;
 
@@ -247,8 +227,7 @@ register int len;
 }
 
 
-static
-putch(c)
+static int putch(int c)
 {
     if(flag == string)
         *pointer++ = c;

--- a/Source/Compiler/CC09/prtree.c
+++ b/Source/Compiler/CC09/prtree.c
@@ -4,7 +4,7 @@
 char *kw[200];
 
 
-getkeys()
+int getkeys(void)
 {
     char kname[20];
     register char *p;
@@ -28,8 +28,7 @@ getkeys()
 }
 
 
-prtree(node,title)
-expnode *node;
+int prtree(expnode *node, char *title)
 {
     if (dflag) {
         fflush(stdout);
@@ -40,8 +39,7 @@ expnode *node;
 }
 
 
-ptree(node)
-register expnode *node;
+int ptree(register expnode *node)
 {
     if (node) {
         pnode(node);
@@ -51,8 +49,7 @@ register expnode *node;
 }
 
 
-pnode(node)
-register expnode *node;
+int pnode(register expnode *node)
 {
     int op,val,i;
 

--- a/Source/Compiler/CC09/regscont.c
+++ b/Source/Compiler/CC09/regscont.c
@@ -1,24 +1,24 @@
 #ifdef REGCONTS
 #include "cj.h"
 
-static wlktr();
-static fixnode();
-static graft();
+static int wlktr(expnode *);
+static int fixnode(expnode *);
+static int graft(expnode *, expnode *);
 
 direct expnode *dregcont,*xregcont,*currexpr;
 /* extern int fixnode(),graft(); */
-extern expnode *subtree(),*treecont(),*regcont();
+extern expnode *subtree(expnode *, expnode *), *treecont(expnode *, int),
+               *regcont(expnode *);
 
 
-clrconts()
+int clrconts(void)
 {
     setdreg(NULL);
     setxreg(NULL);
 }
 
 
-setdreg(tree)
-register expnode *tree;
+int setdreg(register expnode *tree)
 {
     walktree(tree,fixnode);
     if (dregcont) {
@@ -46,8 +46,7 @@ register expnode *tree;
 }
 
 
-setxreg(tree)
-register expnode *tree;
+int setxreg(register expnode *tree)
 {
     walktree(tree,fixnode);
     if (xregcont) {
@@ -75,8 +74,7 @@ register expnode *tree;
 }
 
 
-setcurr(tree)
-register expnode *tree;
+int setcurr(register expnode *tree)
 {
     walktree(tree,fixnode);
     if (currexpr) {
@@ -97,8 +95,7 @@ register expnode *tree;
 }
 
 
-cmptrees(tree,cont)
-register expnode *tree, *cont;
+int cmptrees(register expnode *tree, register expnode *cont)
 {
     if (cont == NULL) return tree == NULL;
     if (tree == NULL) return 0;
@@ -112,9 +109,7 @@ register expnode *tree, *cont;
 }
 
 
-expnode *
-subtree(tree,cont)
-register expnode *tree,*cont;
+expnode * subtree(register expnode *tree, register expnode *cont)
 {
     expnode *t;
 
@@ -125,9 +120,7 @@ register expnode *tree,*cont;
 }
 
 
-expnode *
-treecont(tree,op)
-register expnode *tree;
+expnode *treecont(register expnode *tree, int op)
 {
     expnode *t;
 
@@ -141,9 +134,7 @@ register expnode *tree;
 }
 
 
-expnode *
-regcont(tree)
-register expnode *tree;
+expnode * regcont(register expnode *tree)
 {
     expnode *t;
 
@@ -171,9 +162,7 @@ register expnode *tree;
 }
 
 
-static
-fixnode(tree)
-register expnode *tree;
+static int fixnode(register expnode *tree)
 {
     if (tree) {
         if (tree->op & INDIRECT) {
@@ -199,9 +188,7 @@ register expnode *tree;
 }
 
 
-static
-graft(limb,tree)
-register expnode *limb, *tree;
+static int graft(register expnode *limb, register expnode *tree)
 {
     if (limb && tree->left == NULL && tree->right == NULL) {
         nodecopy(limb,tree);
@@ -211,9 +198,7 @@ register expnode *limb, *tree;
 }
 
 
-expnode *
-treecopy(tree)
-register expnode *tree;
+expnode * treecopy(register expnode *tree)
 {
     expnode *t;
 
@@ -226,8 +211,7 @@ register expnode *tree;
 }
 
 
-rplcnode(tree,reg)
-register expnode *tree;
+int rplcnode(register expnode *tree, int reg)
 {
     tree->op = reg;
     tree->val.num = 0;
@@ -236,20 +220,16 @@ register expnode *tree;
     tree->left = tree->right = NULL;
 }
 
-static int (*walkfunc)();
+static int (*walkfunc)(expnode *);
 
-walktree(tree,funct)
-expnode *tree;
-int (*funct)();
+int walktree(expnode *tree, int (*funct)(expnode *))
 {
     walkfunc = funct;
     wlktr(tree);
 }
 
 
-static
-wlktr(tree)
-register expnode *tree;
+static int wlktr(register expnode *tree)
 {
     if (tree) {
         wlktr(tree->left);

--- a/Source/Compiler/CC09/scale.c
+++ b/Source/Compiler/CC09/scale.c
@@ -25,9 +25,7 @@ static int atoftbl[] = {
 static double *dtbl = atoftbl;
 
 
-static double
-exp5 (power)
-register int power;
+static double exp5(register int power)
 {
 	if (power > 9)
 		return dtbl[(power%10)] * dtbl[((power/10))+9];
@@ -37,10 +35,7 @@ register int power;
 #endif
 
 
-static double
-scale0 (d, cnt, pos)
-double	d;
-register int	cnt, pos;
+static double scale0(double d, register int cnt, register int pos)
 {
 #ifdef _OS9
 	return (pos ? (d * exp5 (cnt)) : (d / exp5 (cnt)));
@@ -50,10 +45,7 @@ register int	cnt, pos;
 }
 
 
-double
-scale(d, cnt, sign)
-double	d;
-int		cnt, sign;
+double scale(double d, int cnt, int sign)
 {
 #ifdef _OS9
 	register unsigned char *dx = &d;

--- a/Source/Compiler/CC09/stats.c
+++ b/Source/Compiler/CC09/stats.c
@@ -15,7 +15,7 @@
  *                             *
  *******************************/
 
-static swcherr();
+static int swcherr(void);
 
 typedef struct casestct {
     struct casestct *clink;     /* next case in case list */
@@ -44,11 +44,11 @@ extern  expnode *dregcont,      /* D register content */
                 *xregcont;      /* X register content */
 #endif
 
-static  expnode *emit(), *getptest(), *gettest(), *sidexp();
+static expnode *emit(expnode *), *getptest(void), *gettest(void), *sidexp(int);
 
-static  symnode *checklabel();
+static symnode *checklabel(void);
 
-statement()
+int statement(void)
 {
    if (sym!=SEMICOL) lastst=0;
 
@@ -107,7 +107,7 @@ tryexp:
 }
 
 
-doif()
+int doif(void)
 {
     register expnode *ptr;
     labstruc tl,fl;
@@ -135,7 +135,7 @@ doif()
         if (sym != SEMICOL) {
             if (et == 0) {
                 et = 1;
-                gen(JMP,tl.labnum = getlabel(),0);
+                gen(JMP,tl.labnum = getlabel(),0,0);
 #ifdef REGCONTS
                 tl.labdreg = dregcont;
                 tl.labxreg = xregcont;
@@ -151,7 +151,7 @@ doif()
 }
 
 
-dowhile()
+int dowhile(void)
 {
     register expnode *ptr;
     labstruc brk,cnt,*savbreak,*savcont;
@@ -180,7 +180,7 @@ dowhile()
     if (sym == SEMICOL)
         tlab = cnt.labnum;
     else {
-        gen(JMP,cnt.labnum,0);
+        gen(JMP,cnt.labnum,0,0);
         label(tlab = getlabel());
         statement();
     }
@@ -195,7 +195,7 @@ dowhile()
 }
 
 
-doswitch()
+int doswitch(void)
 {
     register expnode *ptr;
     labstruc brk,*savbreak;
@@ -238,16 +238,16 @@ doswitch()
     else experr();
     need(RPAREN);
 
-    gen(JMP,tests=getlabel(),0);
+    gen(JMP,tests=getlabel(),0,0);
     statement();
 
-    if (lastst == 0) gen(JMP,setlabel(&brk),0);
+    if (lastst == 0) gen(JMP,setlabel(&brk),0,0);
 
     label(tests);
     cptr = caseptr;
     while (cptr) {
         temp = cptr->clink;
-        gen(JMPEQ,cptr->clab,cptr->cval);
+        gen(JMPEQ,cptr->clab,cptr->cval,0);
         cptr->clink = freecase;
         freecase = cptr;
         cptr = temp;
@@ -257,7 +257,7 @@ doswitch()
     clrconts();
 #endif
     if (deflabel) {
-        gen(JMP,deflabel,0);
+        gen(JMP,deflabel,0,0);
 #ifdef REGCONTS
         dregcont = treecopy(brk.labdreg);
         xregcont = treecopy(brk.labxreg);
@@ -274,7 +274,7 @@ doswitch()
 }
 
 
-docase()
+int docase(void)
 {
     register casnode *ptr;
     register int val;
@@ -302,7 +302,7 @@ docase()
 }
 
 
-dodefault()
+int dodefault(void)
 {
     getsym();
     if (swflag == 0) swcherr();
@@ -315,13 +315,13 @@ dodefault()
 }
 
 
-static swcherr()
+static int swcherr(void)
 {
        error("no switch statement");
 }
 
 
-dodo()
+int dodo(void)
 {
     labstruc brk,cnt,*savbreak,*savcont;
     int looptop;
@@ -353,7 +353,7 @@ dodo()
 }
 
 
-dofor()
+int dofor(void)
 {
     labstruc brk,cnt,tst,*savbreak,*savcont;
     int slab;
@@ -383,7 +383,7 @@ dofor()
     if (sym!=SEMICOL) {
         /* there IS a test */
         tptr = gettest();
-        gen(JMP,setlabel(&tst),0);
+        gen(JMP,setlabel(&tst),0,0);
     }
     need(SEMICOL);
 
@@ -408,7 +408,7 @@ dofor()
         uselabel(&tst);
         cnt.labnum = slab;
         dotest(tptr,&cnt,&brk,FALSE);
-    } else gen(JMP,slab,0);
+    } else gen(JMP,slab,0,0);
 
     uselabel(&brk);
 
@@ -417,7 +417,7 @@ dofor()
 }
 
 
-doreturn()
+int doreturn(void)
 {
     getsym();
     if (sym != SEMICOL) {
@@ -443,19 +443,19 @@ doreturn()
 common:
 #endif
                     if(ptr->op!=FREG) {
-                        gen(LOADIM,UREG,FREG);
-                        gen(PUSH,UREG);
+                        gen(LOADIM,UREG,FREG,0);
+                        gen(PUSH,UREG,0,0);
 #ifdef  DOFLOATS
                         switch(ftype) {
                             case FLOAT:
                             case DOUBLE:
-                                gen(DBLOP,MOVE,ftype);
+                                gen(DBLOP,MOVE,ftype,0);
                                 break;
                             default:
-                                gen(LONGOP,MOVE);
+                                gen(LONGOP,MOVE,0,0);
                         }
 #else
-                        gen(LONGOP,MOVE);
+                        gen(LONGOP,MOVE,0,0);
 #endif
                     }
                     break;
@@ -469,12 +469,12 @@ common:
     }
 
     modstk(0);
-    gen(RETURN,0,0);
+    gen(RETURN,0,0,0);
     lastst=RETURN;
 }
 
 
-dobreak()
+int dobreak(void)
 {
     if (breakptr) modnjmp(breakptr);
     else error("break error");
@@ -483,7 +483,7 @@ dobreak()
 }
 
 
-docont()
+int docont(void)
 {
     if (contptr) modnjmp(contptr);
     else error("continue error");
@@ -492,15 +492,14 @@ docont()
 }
 
 
-modnjmp(labptr)
-register labstruc *labptr;
+int modnjmp(register labstruc *labptr)
 {
     modstk(labptr->labsp);
-    gen(JMP,setlabel(labptr),0);
+    gen(JMP,setlabel(labptr),0,0);
 }
 
 
-dogoto()
+int dogoto(void)
 {
     register symnode *ptr;
 
@@ -509,7 +508,7 @@ dogoto()
     if (sym != NAME) error("label required");
     else {
         if (ptr = checklabel()) {
-            gen(GOTO,ptr->offset,0);
+            gen(GOTO,ptr->offset,0,0);
             ptr->x.labflg |= GONETO;
         }
         getsym();
@@ -518,7 +517,7 @@ dogoto()
 }
 
 
-dolabel()
+int dolabel(void)
 {
     register symnode *ptr;
 
@@ -526,7 +525,7 @@ dolabel()
         if (ptr->storage == STATIC) multidef();
         else {
             ptr->storage = STATIC;
-            gen(LABEL,ptr->offset,0);
+            gen(LABEL,ptr->offset,0,0);
             ptr->x.labflg |= DEFINED;
         }
     }
@@ -538,8 +537,7 @@ dolabel()
 }
 
 
-static symnode *
-checklabel()
+static symnode * checklabel(void)
 {
     register symnode *ptr;
 
@@ -565,8 +563,7 @@ checklabel()
 }
 
 
-static expnode *
-sidexp(l)
+static expnode *sidexp(int l)
 {
     register expnode *ptr;
 
@@ -575,9 +572,7 @@ sidexp(l)
 }
 
 
-static expnode *
-emit(ptr)
-register expnode *ptr;
+static expnode * emit(register expnode *ptr)
 {
     chkdecl(ptr);
     switch (ptr->op) {
@@ -594,8 +589,7 @@ register expnode *ptr;
 }
 
 
-static expnode *
-getptest()
+static expnode * getptest(void)
 {
     register expnode *ptr;
 
@@ -606,8 +600,7 @@ getptest()
 }
 
 
-static expnode *
-gettest()
+static expnode * gettest(void)
 {
     register expnode *ptr;
 
@@ -617,9 +610,7 @@ gettest()
 }
 
 
-dotest(ptr,tl,fl,nj)
-register expnode *ptr;
-labstruc *tl,*fl;
+int dotest(register expnode *ptr, labstruc *tl, labstruc *fl, int nj)
 {
     if (ptr) {
         tranbool(ptr,tl,fl,nj);

--- a/Source/Compiler/CC09/tb.c
+++ b/Source/Compiler/CC09/tb.c
@@ -6,8 +6,7 @@ typedef struct {
 } expnode;
 
 
-tranrel(op)
-short op;
+int tranrel(short op)
 {
     expnode *lhs,*rhs;
 

--- a/Source/Compiler/CC09/tranexp.c
+++ b/Source/Compiler/CC09/tranexp.c
@@ -4,7 +4,7 @@ direct int shiftflag;
 #ifdef REGCONTS
 extern direct expnode *dregcont,*xregcont,*currexpr;
 #endif
-extern expnode *transexp();
+extern expnode *transexp(expnode *);
 
 #define swap(x,y) {expnode *t; t=x; x=y; y=t;}
 
@@ -14,8 +14,7 @@ extern expnode *transexp();
  *                                     *
  ***************************************/
 
-lddexp(tree)
-register expnode *tree;
+int lddexp(register expnode *tree)
 {
     loadexp(tree);
     if (tree->op != DREG) {
@@ -29,8 +28,7 @@ register expnode *tree;
 }
 
 
-ldxexp(tree)
-register expnode *tree;
+int ldxexp(register expnode *tree)
 {
     tranxexp(tree);
     if (tree->op != XREG || tree->val.num) {
@@ -44,8 +42,7 @@ register expnode *tree;
 }
 
 
-loadexp(tree)
-register expnode *tree;
+int loadexp(register expnode *tree)
 {
     switch(tree->type) {
         case LONG:
@@ -65,8 +62,7 @@ register expnode *tree;
 }
 
 
-doload(tree)
-register expnode *tree;
+int doload(register expnode *tree)
 {
     switch (tree->op) {
         case STRING:
@@ -121,8 +117,7 @@ register expnode *tree;
 }
 
 
-expnode *tranexp(tree)
-register expnode *tree;
+expnode *tranexp(register expnode *tree)
 {
     register int op;
 
@@ -171,13 +166,13 @@ register expnode *tree;
                 break;
             case LTOI:
                 tranlexp(tree->left);
-                gen(LTOI,NODE,tree->left);
+                gen(LTOI,NODE,tree->left,0);
                 tree->op = DREG;
                 break;
 #ifdef  DOFLOATS
             case DTOI:
                 dload(tree->left);
-                gen(DBLOP,DTOI);
+                gen(DBLOP,DTOI,0,0);
                 tree->op = DREG;
                 break;
 #endif
@@ -193,7 +188,7 @@ register expnode *tree;
             case COMPL:
             case NEG:
                 lddexp(tree->left);
-                gen(op);
+                gen(op,0,0,0);
 #ifdef REGCONTS
                 setdreg(tree);      /* set D contents */
 #else
@@ -228,9 +223,7 @@ register expnode *tree;
 }
 
 
-tranbinop(op,node)
-int op;
-expnode *node;
+int tranbinop(int op, expnode *node)
 {
     register expnode *lhs,*rhs;
     int s;
@@ -254,7 +247,7 @@ expnode *node;
         case MINUS:
             if (!isaleaf(rhs) ) {
                 loadexp(rhs);
-                gen(PUSH,rhs->op);
+                gen(PUSH,rhs->op,0,0);
                 rhs->op=STACK;
                 lddexp(lhs);
             } else {
@@ -272,13 +265,13 @@ expnode *node;
                 swap(lhs,rhs);
 
             if (isreg(lhs->op)) {
-                gen(PUSH,lhs->op);
+                gen(PUSH,lhs->op,0,0);
                 lddexp(rhs);
                 rhs->op = STACK;
             } else {
                 lddexp(lhs);
                 if (!isaleaf(rhs)) {
-                    gen(PUSH,DREG);
+                    gen(PUSH,DREG,0,0);
                     lddexp(rhs);
                     rhs->op=STACK;
                 } else {
@@ -321,7 +314,7 @@ doshift:        if ((unsigned)s <= 4) {
                     while (s--)
                         switch (op) {
                             case SHL:
-                                gen(IDOUBLE);
+                                gen(IDOUBLE,0,0,0);
                                 break;
                             case SHR:
                                 gen ((lhs->size == 1) ? CHALVE : HALVE);
@@ -352,9 +345,9 @@ doshift:        if ((unsigned)s <= 4) {
         case UMOD:
         case MOD:
 rest:       loadexp(lhs);
-            gen(PUSH,lhs->op);
+            gen(PUSH,lhs->op,0,0);
             lddexp(rhs);
-            gen(op);
+            gen(op,0,0,0);
 #ifdef  REGCONTS
             setxreg(NULL);  /* clear X contents */
 #endif
@@ -373,7 +366,7 @@ out1: node->op = DREG;
 }
 
 
-isashift(x)
+int isashift(int x)
 {
     /* returns whether x is a suitable candidate for
     * shifting code in multiplication or division
@@ -390,8 +383,7 @@ isashift(x)
 }
 
 
-dobool(tree)
-register expnode *tree;
+int dobool(register expnode *tree)
 {
     /*  to evaluate expressions of the form "e1 <rel> e2",
         other than in tests */
@@ -408,7 +400,7 @@ register expnode *tree;
     /*  put in 'true' condition */
     uselabel(&l1);
     gen(LOAD,DREG,CONST,1);
-    gen(JMP,l1.labnum=getlabel(),1);
+    gen(JMP,l1.labnum=getlabel(),1,0);
 
     /* put in 'false' condition */
     uselabel(&l2);
@@ -423,9 +415,7 @@ register expnode *tree;
 }
 
 
-doquery(tree,loadfunc)
-register expnode *tree;
-int (*loadfunc)();
+int doquery(register expnode *tree, int (*loadfunc)(expnode *))
 {
     labstruc l1,l2;
 
@@ -445,7 +435,7 @@ int (*loadfunc)();
     /* and load the 'true' expression */
     (*loadfunc)(tree->left);
     /* then jump round the 'false' expression */
-    gen(JMP,l1.labnum=getlabel(),0);
+    gen(JMP,l1.labnum=getlabel(),0,0);
 
     /* put in the 'false' label */
     uselabel(&l2);
@@ -460,8 +450,7 @@ int (*loadfunc)();
 }
 
 
-docall(node)
-expnode *node;
+int docall(expnode *node)
 {
     register expnode *lhs,*rhs;
     int oldsp;
@@ -474,13 +463,13 @@ expnode *node;
             if (lhs->op == LCONST) pushcon(lhs);
             else {
                 lload(lhs);
-                gen(LONGOP,STACK);
+                gen(LONGOP,STACK,0,0);
             }
         }
 #ifdef DOFLOATS
         else if (isfloat(lhs)) {
             dload(lhs);
-            gen(DBLOP,STACK);
+            gen(DBLOP,STACK,0,0);
         }
 #endif
         else {
@@ -499,7 +488,7 @@ expnode *node;
 #endif
                     ;
             }
-            gen(PUSH,lhs->op);
+            gen(PUSH,lhs->op,0,0);
         }
     }
 
@@ -515,7 +504,7 @@ expnode *node;
         }
     }
 #endif
-    gen(CALL,NODE,node->left);
+    gen(CALL,NODE,node->left,0);
 
     sp = modstk(oldsp);
 
@@ -526,8 +515,7 @@ expnode *node;
 }
 
 
-isdleaf(node)
-register expnode *node;
+int isdleaf(register expnode *node)
 {
     expnode *p;
 
@@ -552,8 +540,7 @@ register expnode *node;
 }
 
 
-regandcon(p)
-register expnode *p;
+int regandcon(register expnode *p)
 {
     switch (p->op) {
         case PLUS:
@@ -564,15 +551,13 @@ register expnode *p;
 }
 
 
-isxleaf(node)
-register expnode *node;
+int isxleaf(register expnode *node)
 {
     return (node->sux<2);
 }
 
 
-isaddress(p)
-register expnode *p;
+int isaddress(register expnode *p)
 {
     switch (p->op) {
         case PLUS:
@@ -586,8 +571,7 @@ register expnode *p;
 }
 
 
-getinx(node)
-register expnode *node;
+int getinx(register expnode *node)
 {
     if (node->op & INDIRECT) {
         node->op&= NOTIND;
@@ -598,8 +582,7 @@ register expnode *node;
 }
 
 
-doass(node)
-register expnode *node;
+int doass(register expnode *node)
 {
     register expnode *lhs,*rhs,*savlhs;
 
@@ -672,9 +655,7 @@ register expnode *node;
 }
 
 
-expnode *
-transexp(tree)
-register expnode *tree;
+expnode * transexp(register expnode *tree)
 {
     switch (tree->op) {
         case STAR:
@@ -697,8 +678,7 @@ register expnode *tree;
 }
 
 
-assop(node,op)
-expnode *node;
+int assop(expnode *node, int op)
 {
     register expnode *lhs,*rhs;
 #ifdef REGCONTS
@@ -731,12 +711,12 @@ expnode *node;
                 } else {
                     lddexp(rhs);
                     if (op == MINUS) {
-                        gen(NEG);
+                        gen(NEG,0,0,0);
 #ifdef REGCONTS
                         setdreg(NULL);
 #endif
                     }
-                    gen(LEA,lhs->op,DREG);
+                    gen(LEA,lhs->op,DREG,0);
                 }
                 node->op = lhs->op;
                 node->val.num = 0;
@@ -746,9 +726,9 @@ expnode *node;
             case XOR:
                 goto ord;
             default:
-                gen(PUSH,lhs->op);
+                gen(PUSH,lhs->op,0,0);
                 lddexp(rhs);
-                gen(op);
+                gen(op,0,0,0);
         }
     } else {
 #ifdef REGCONTS
@@ -765,7 +745,7 @@ ord:
             setdreg(NULL);
         }
 #endif
-        if (lhs->type == CHAR) gen(CTOI);
+        if (lhs->type == CHAR) gen(CTOI,0,0,0);
         switch (op) {
             case AND:
             case OR:
@@ -790,18 +770,18 @@ ord:
 #endif
                     (lhs->op & NOTIND) != YIND
                         && (lhs->op & NOTIND) != UIND) stackx(lhs);
-                gen(PUSH,DREG);
+                gen(PUSH,DREG,0,0);
                 lddexp(rhs);
                 if (op == MINUS) op = RSUB;
-                gen(op,DREG,STACK);
+                gen(op,DREG,STACK,0);
         }
     }
 #ifdef REGCONTS
     if (inreg) {
         if (!isaleaf(lhs)) {
-            gen(PUSH,DREG);
+            gen(PUSH,DREG,0,0);
             transexp(lhs);
-            gen(LOAD,DREG,STACK);
+            gen(LOAD,DREG,STACK,0);
         } else transexp(lhs);
     }
 #endif
@@ -814,19 +794,17 @@ ord:
 }
 
 
-stackx(node)
-register expnode *node;
+int stackx(register expnode *node)
 {
     if ((node->op & NOTIND) == NAME) return;
     getinx(node);
     if(node->val.num) gen(LEA,XREG,CONST,node->val.num);
-    gen(PUSH,XREG);
+    gen(PUSH,XREG,0,0);
     node->op=STACK | INDIRECT;
 }
 
 
-dostar(node)
-register expnode *node;
+int dostar(register expnode *node)
 {
     register expnode *lhs;
     register int op;
@@ -923,9 +901,7 @@ fix:            node->val.sp = lhs->val.sp;
 }
 
 
-dotoggle(node,dest)
-register expnode *node;
-register int dest;
+int dotoggle(register expnode *node, register int dest)
 {
     register expnode *lhs;
     int op, size, reg;
@@ -1019,8 +995,7 @@ register int dest;
     shiftflag = 0;
 }
 
-loadxexp(p)
-register expnode *p;
+int loadxexp(register expnode *p)
 {
     tranxexp(p);
     if (p->op != XREG || p->val.num) {
@@ -1032,8 +1007,7 @@ register expnode *p;
     p->op = XREG;
 }
 
-tranxexp(node)
-expnode *node;
+int tranxexp(expnode *node)
 {
     register expnode *lhs,*rhs;
     int lhsval,rhsval,op,newop;
@@ -1095,12 +1069,12 @@ expnode *node;
                     lddexp(rhs);
                     tranxexp(lhs);
                     if (op == MINUS) {
-                        gen(NEG);
+                        gen(NEG,0,0,0);
 #ifdef REGCONTS
                         setdreg(NULL);
 #endif
                     }
-                    gen(LEAX,DREG,lhs->op);
+                    gen(LEAX,DREG,lhs->op,0);
 #ifdef REGCONTS
                     setxreg(node);
 #endif
@@ -1155,12 +1129,12 @@ expnode *node;
                 else {
                     lddexp(rhs);
                     if (op == MINUS) {
-                        gen(NEG,0,0);
+                        gen(NEG,0,0,0);
 #ifdef REGCONTS
                         setdreg(NULL);
 #endif
                     }
-done:               gen(LEAX,DREG,newop);
+done:               gen(LEAX,DREG,newop,0);
 #ifdef REGCONTS
                     setxreg(node);
 #endif
@@ -1181,7 +1155,7 @@ cant:       tranexp(node);
 }
 
 
-isreg(r)
+int isreg(int r)
 {
 #ifdef USE_YREG
     return (r==UREG || r==YREG);
@@ -1189,4 +1163,3 @@ isreg(r)
     return (r==UREG);
 #endif
 }
-

--- a/Source/Compiler/COpt/optim.c
+++ b/Source/Compiler/COpt/optim.c
@@ -1,11 +1,14 @@
 #include "op.h"
 #include "actions.h"
+#include <stdint.h>
 
 direct int opsdone;
 int labelnum = 0;
 action *acslots[128];
 
 static char empty[1] = {'\0'};	/* the empty string */
+#define REF1 ((char *)(intptr_t)1)
+#define REF2 ((char *)(intptr_t)2)
 
 extern direct chain *freeins;
 extern char *bratab[];
@@ -19,7 +22,7 @@ char *
 strinst (val)
 char *val;
 {
-	switch ((int) val) {
+	switch ((intptr_t) val) {
 		case 0:		return zero;
 		case 1:		return p1;
 		case 2:		return p2;
@@ -71,10 +74,10 @@ char *line;
 				i->mnp = NULL;
 				break;
 			case '1':
-				i->mnp = (char *)1;
+				i->mnp = REF1;
 				break;
 			case '2':
-				i->mnp = (char *)2;
+				i->mnp = REF2;
 				break;
 			default:
 				error ("bad opcode reference");
@@ -106,10 +109,10 @@ char *line;
 				i->opp = NULL;
 				break;
 			case '1':
-				i->opp = (char *)1;
+				i->opp = REF1;
 				break;
 			case '2':
-				i->opp = (char *)2;
+				i->opp = REF2;
 				break;
 			default:
 				error ("bad operand reference");
@@ -270,7 +273,7 @@ restart:
                 }
                 if (ap->mnp && match(i->mnem,ap->mnp) == 0) break;
                 if (ap->opp) {
-                    if ((int)ap->opp == 1) {
+                    if (ap->opp == REF1) {
                         if (i->pred == &ilist) break;
                         if (match(i->args,i->pred->args) == 0) break;
                     } else if (match(i->args,ap->opp) == 0) break;
@@ -303,8 +306,8 @@ restart:
 		for (ap = a->repp, mp = a->actp; ap; ap = ap->nxtins,mp = mp->nxtins) {
 			char *ts;
 			if (ap->mnp) {
-				if ((int)ap->mnp == 1) /* do nothing, same as NULL */;
-				else if ((int)ap->mnp == 2) strcpy(i->mnem,i->pred->mnem);
+				if (ap->mnp == REF1) /* do nothing, same as NULL */;
+				else if (ap->mnp == REF2) strcpy(i->mnem,i->pred->mnem);
 				else if (ts = index(ap->mnp, '\\')) {	// mnp has \#
 					if (*(ts+1) > '0' && *(ts+1) < '3')
 						matchcpy (ap->mnp,
@@ -317,8 +320,8 @@ restart:
 				}
             }
             if (ap->opp) {
-				if ((int)ap->opp == 1) /* do nothing, same as NULL */;
-				else if ((int)ap->opp == 2) strcpy(i->args,i->pred->args);
+				if (ap->opp == REF1) /* do nothing, same as NULL */;
+				else if (ap->opp == REF2) strcpy(i->args,i->pred->args);
 				else if (ts = index(ap->opp, '\\')) {	// opp has \#
 					if (*(ts+1) > '0' && *(ts+1) < '3')
 						matchcpy (ap->opp,

--- a/Source/Compiler/CPP/defdir.h
+++ b/Source/Compiler/CPP/defdir.h
@@ -1,13 +1,19 @@
 /*
 	@(#)defdir.h	2.2.1	6/15/87
 */
+#ifndef DEFNAME
 #define DEFNAME "/dd"
+#endif
+#ifndef DEVNAME
 #define DEVNAME "/d0"
+#endif
 
+#ifndef DEFDIR
 #if defined(vms)
 #	define DEFDIR "Osk$Defs:"
 #elif defined(sys5)
 #	define DEFDIR "/user/defs"
 #else
 #	define DEFDIR "/dd/defs"
+#endif
 #endif

--- a/Source/Compiler/CPP/dues.c
+++ b/Source/Compiler/CPP/dues.c
@@ -73,7 +73,7 @@ doinclude()
 					putesc(NEWFNAME, filename, modname);
 					inclptr = nptr;
 
-					putesc(NEWLINO, 0);
+					putesc(NEWLINO, LINEARG(0));
 					setline(lineno = 0);
 					in = fp;
 					return;

--- a/Source/Compiler/CPP/main.c
+++ b/Source/Compiler/CPP/main.c
@@ -218,7 +218,7 @@ done: ;
 	while (getline1() != EOF) {
 		if (nxtlno != lineno - 1) {     /*   if line number changed */
 			nxtlno = lineno - 1;        /*   tell the compiler */
-			putesc(NEWLINO, nxtlno);
+			putesc(NEWLINO, LINEARG(nxtlno));
 		}
 		fprintf(out, "%s\n", line);     /*   write out expanded line */
 		if (ferror(stdout)) {

--- a/Source/Compiler/CPP/misc.c
+++ b/Source/Compiler/CPP/misc.c
@@ -81,7 +81,7 @@ char	*arg, *arg1;
 			fprintf(out, "%c%c\n%s\n%s\n", ESCHAR, type, arg, arg1);
 			break;
 		case NEWLINO:
-			fprintf(out,"%c%c\n%d\n",ESCHAR, type, (int)arg);
+			fprintf(out,"%c%c\n%d\n",ESCHAR, type, (int)(intptr_t)arg);
 			break;
 		default:
 			fprintf(out,"%c%c\n%s\n",ESCHAR, type, arg);

--- a/Source/Compiler/CPP/parse.c
+++ b/Source/Compiler/CPP/parse.c
@@ -122,14 +122,14 @@ getword(word,count)
 register char	*word;
 register int	count;
 {
-	while(--count > 0 && (isalnum(cch) || cch == '_')) {
+	while(--count > 0 && (isalnum(cch) || cch == '_' || cch == '$')) {
 		*word++ = cch;
 		gch(KEEPSP);
 	}
 	*word = '\0';
 
 /* eat any excess chars from word */
-	while(isalnum(cch) || cch == '_')
+	while(isalnum(cch) || cch == '_' || cch == '$')
 		gch(KEEPSP);
 }
 

--- a/Source/Compiler/CPP/parse.c
+++ b/Source/Compiler/CPP/parse.c
@@ -170,7 +170,7 @@ newline()
 			strcpy(modname,inclptr->modname);
 			inclptr = inclptr->next;
 			putesc(NEWFNAME,filename,modname);
-			putesc(NEWLINO,lineno);
+			putesc(NEWLINO,LINEARG(lineno));
 		} else return 0;
 	}
 }

--- a/Source/Compiler/CPP/prep.h
+++ b/Source/Compiler/CPP/prep.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdint.h>
 #include "defdir.h"
 
 #ifdef MAIN
@@ -60,6 +61,7 @@ extern int errno;
 #endif
 
 #define HIDER       0x7f    /* a seldom-used ascii value to hide quotes */
+#define LINEARG(n)  ((char *)(intptr_t)(n))
 
 #define SKIPSP      0       /* gch() skips white space and comments */
 #define KEEPSP      1       /* gch() skips comments, keeps white space */
@@ -156,7 +158,7 @@ extern long parsexp();
 extern long primary();
 
 extern macro *addmac();
-extern char *savestr(), *setfile(), *makename();
+extern char *grab(), *copystr(), *savestr(), *setfile(), *makename();
 
 extern gch();
 extern nxtch();

--- a/Source/Compiler/CPP/scan.c
+++ b/Source/Compiler/CPP/scan.c
@@ -10,6 +10,9 @@
 	I hope the comments help...
 */
 
+#ifdef strcpy
+# undef strcpy
+#endif
 extern char *strcpy(), *copystr();
 extern macro *findmac();
 

--- a/Source/Compiler/DCC/dcc.c
+++ b/Source/Compiler/DCC/dcc.c
@@ -11,6 +11,7 @@
 # include <module.h>
 #else
 # include <signal.h>
+# include <sys/wait.h>
 #endif
 #include <errno.h>
 #include <fcntl.h>
@@ -136,6 +137,11 @@ char **argv;
 						mflag = TRUE;
 						break;
 
+					case 'L':       /* use LWTOOLS assembler syntax (default) */
+						lwflag = TRUE;
+						oflag = FALSE;          /* dco68 expects RMA syntax */
+						break;
+
 					case 'n':                      /* give module a name (L) */
 						*--p = '-';
 						modname = p;
@@ -173,6 +179,11 @@ char **argv;
 							goto saver;
 						strcat (rlib, "/");
 						goto saver;
+						break;
+
+					case 'R':                 /* use legacy RMA/RLINK flow */
+						lwflag = FALSE;
+						oflag = TRUE;
 						break;
 
 					case 's':                       /* no stack checking (C) */
@@ -354,6 +365,9 @@ saver:
 			if (pflag)
 				splcat ("-p");          /* wants profiler code */
 
+			if (lwflag)
+				splcat ("-L");          /* LWTOOLS-compatible assembly */
+
 			splcat (srcfile);
 
 			trmcat ();
@@ -365,7 +379,7 @@ saver:
 		}
 
 		/* now assemble and perhaps optimize it */
-		if (aflag || nullflag || (suffarray[j] == 'r')) {
+		if (aflag || nullflag || (suffarray[j] == 'r') || (lwflag && (suffarray[j] == 'o'))) {
 			lasfilp = 0;                /* is .r so no work to do */
 		} else {
 			/* don't optimize ".a" or ".o" files */
@@ -409,25 +423,34 @@ saver:
 
 				if ((filcnt == 1) && !rflag) {
 					strcpy (destfile, tmpname);
-					chgsuff (destfile, 'r');
+					chgsuff (destfile, lwflag ? 'o' : 'r');
 				} else {
 					if (fflag && rflag) {
 						strcpy (destfile, rlib);
 						strcat (destfile, objname);
 					} else {
-						chgsuff (namarray[j], 'r');
+						chgsuff (namarray[j], lwflag ? 'o' : 'r');
 						strcpy (destfile, rlib);
 						strcat (destfile, namarray[j]);
 					}
 				}
-				sprintf (ofn, "-o=%s", destfile);
-				splcat (ofn);
+				if (lwflag) {
+					splcat ("--format=obj");
+					splcat ("--pragma=pcaspcr,condundefzero,undefextern,dollarnotlocal,noforwardrefmax,export");
+					splcat ("--no-warn=ifp1");
+					splcat ("--6309");
+					splcat ("-o");
+					splcat (destfile);
+				} else {
+					sprintf (ofn, "-o=%s", destfile);
+					splcat (ofn);
+				}
 
 				splcat (srcfile);
 
 				trmcat ();
 				lasfilp = destfile;
-				runit (ASSEMBLER, 0);
+				runit (lwflag ? LWASSEMBLER : ASSEMBLER, 0);
 				if (deltmpflg)
 					unlink (srcfile);
 			}
@@ -442,31 +465,42 @@ saver:
 
 	if (!fflag)
 		chgsuff (objname, '\0');
-	sprintf (ofn, "-o=%s", objname);
-	splcat (ofn);
+	if (lwflag) {
+		splcat ("--format=os9");
+		splcat ("--entry=_cstart");
+		sprintf (ofn, "--output=%s", objname);
+		splcat (ofn);
+	} else {
+		sprintf (ofn, "-o=%s", objname);
+		splcat (ofn);
+	}
 
-	if (edition)
+	if (!lwflag && edition)
 		splcat (edition);
-	if (mflag)
+	if (mflag && lwflag) {
+		sprintf (ofn, "--map=%s.map", objname);
+		splcat (ofn);
+	} else if (mflag) {
 		splcat ("-m");
-	if (xtramem)
+	}
+	if (!lwflag && xtramem)
 		splcat (xtramem);
-	if (modname)
+	if (!lwflag && modname)
 		splcat (modname);
-	if (s2flg)
+	if (!lwflag && s2flg)
 		splcat ("-s");
 
 	if (!(p = chkccdev ()))
 		error ("can't find default drive");
 
 	if (bflag) {
-		strcpy (ofn, mainline);	/* use cstart.r or whatever */
+		strcpy (ofn, mainline);	/* use alternate startup object */
 	} else {
-		sprintf (ofn, "%s%s%s", p, libdir, mainline);	/* global */
+		sprintf (ofn, "%s%s%s", p, libdir, lwflag ? "cstart.o" : mainline);
 	}
 	splcat (ofn);
 
-	if ((filcnt == 1) && (suffarray[0] != 'r')) {
+	if ((filcnt == 1) && (suffarray[0] != 'r') && !(lwflag && (suffarray[0] == 'o'))) {
 		splcat (thisfilp = destfile);
 	} else {
 		for (thisfilp = 0, j = 0; j < filcnt; ++j) {
@@ -476,6 +510,33 @@ saver:
 
 	for (j = 0; j < libcnt; j++) {
 		splcat (libarray[j]);
+	}
+
+	if (lwflag) {
+		if (!xflag) {
+			sprintf (ofn, "-L%s%s", p, libdir);
+			splcat (ofn);
+		}
+
+		if (lgflg)
+			splcat ("-lcgfx");
+
+		if (llflg)
+			splcat ("-llexlib");
+
+		if (lsflg)
+			splcat ("-lsys");
+
+		if (p2flg)
+			splcat ("-ldbg");
+
+		splcat (tflag ? "-lct" : "-lc");
+
+		trmcat ();
+		lasfilp = 0;
+		runit (LWLINKER, 0);
+		cleanup ();
+		exit (0);
 	}
 
 	if (lgflg) {
@@ -521,8 +582,16 @@ int code;
 #else
 	if ((childid = fork()) == 0) { /* we're the child */
 		char foo[4096];
+		int rc;
 		sprintf(foo, "%s%s", cmd, parmbuf);
-		exit(system (foo)); /* don't clean up */
+		rc = system (foo);
+		if (rc == -1)
+			exit(1);
+		if (WIFEXITED(rc))
+			exit(WEXITSTATUS(rc));
+		if (WIFSIGNALED(rc))
+			exit(128 + WTERMSIG(rc));
+		exit(1);
 	} else if (childid < 0) { /* fork failed */
 		error ("can't run '%s' -- fork() failed, reason: %s", cmd, strerror(errno));
 		return;
@@ -667,11 +736,13 @@ usage()
 		"   -dSYM[=val]  Define a preprocessor symbol",
 		"   -f=<path>    Output to path",
 		"   -k           Use maximum K&R compatibility mode",
+		"   -L           Use LWTOOLS lwasm/lwlink object and link flow (default)",
 		"   -o           Do not run optimizer",
 		"   -O           Stop after optimizing assembly code",
 		"   -p           Add profiling code",
 		"   -P           Use special debugging profiler and library",
-		"   -r           Stop after assembly (do not link)",
+		"   -r           Stop after object generation (do not link)",
+		"   -R           Use legacy RMA/RLINK object and link flow",
 		"   -s           Disable stack checks",
 		"   -T[=path]    Use alternate temporary directory",
 		"   -q           Quiet mode (write to 'c.errors' instead of screen)",
@@ -682,14 +753,14 @@ usage()
 		"   -b=<path>    Use an alternate \"cstart\"",
 		"   -e<#>        Set edition of output module",
 		"   -l=<path>    Link with a library file",
-		"   -lg          Link with cgfx.l             (Graphics library)",
-		"   -ll          Link with lexlib.l         (Lex helper library)",
-		"   -ls          Link with sys.l                (System library)",
+		"   -lg          Link with graphics library",
+		"   -ll          Link with lex helper library",
+		"   -ls          Link with system library",
 		"   -M           Ask linker for linkage map",
 		"   -m<##[K]>    Set memory size for output module",
 		"   -n=<name>    Set name of output module",
 		"   -S           Ask linker for symbol table",
-		"   -t           Link with clibt.l (Transcendental math library)",
+		"   -t           Link with transcendental math library",
 		"   -x           Use current directory for the main library",
 		NULL
 	};

--- a/Source/Compiler/DCC/dcc.h
+++ b/Source/Compiler/DCC/dcc.h
@@ -23,6 +23,8 @@
 #define OPTIMIZER	"dco68"
 #define ASSEMBLER	"rma"
 #define LINKER		"rlink"
+#define LWASSEMBLER	"lwasm"
+#define LWLINKER	"lwlink"
 
 direct int	aflag = FALSE,
 			bflag = FALSE,
@@ -34,7 +36,7 @@ direct int	aflag = FALSE,
 			lv2flag = FALSE,
 			lsflg = FALSE,
 			mflag = FALSE,
-			oflag = TRUE,
+			oflag = FALSE,
 			o2flg = FALSE,
 			pflag = FALSE,
 			p2flg = FALSE,
@@ -52,6 +54,7 @@ direct int	aflag = FALSE,
 			filcnt = 0,
 			hello = FALSE,
 			libcnt = 0,
+			lwflag = TRUE,
 			maccnt = 0,
 			newopath = 0,
 			nullflag = FALSE,
@@ -64,11 +67,19 @@ direct char	*thisfilp = 0,
 direct int	frkprmsiz = 0;
 direct char	*frkprmp = 0;
 
-direct char	*tmproot[] = { "/R", "/R0", "/DD/TMP"};
+#ifndef DCC_LIBDIR
+# define DCC_LIBDIR "/lib/"
+#endif
+
+#ifndef DCC_DEFDRIVE
+# define DCC_DEFDRIVE "/dd"
+#endif
+
+	direct char	*tmproot[] = { "/R", "/R0", "/DD/TMP"};
 
 direct char	*tmptail = "ctmp.XXXXXX";
-direct char	*libdir = "/lib/";
-direct char	*defdrive = "/dd";
+	direct char	*libdir = DCC_LIBDIR;
+	direct char	*defdrive = DCC_DEFDRIVE;
 
 char		tmpname[64] = "";
 char		rlib[60] = "";

--- a/Source/Compiler/DCC/dcc.hlp
+++ b/Source/Compiler/DCC/dcc.hlp
@@ -28,11 +28,13 @@ General options:
 	-dSYM[=val]	Define a preprocessor symbol
 	-f=<path>	Output to path
 	-k			Pre-process for maximum K&R compatibility
+	-L			Use LWTOOLS lwasm/lwlink object and link flow (default)
 	-o			Skip running the optimizer
 	-O			Stop after optimizing assembly code
 	-p			Add profiling code
 	-P			Use special debugging profiler and library
-	-r			Stop after assembly (do not link)
+	-r			Stop after object generation (do not link)
+	-R			Use legacy RMA/RLINK object and link flow
 	-s			Disable stack checking (be careful!)
 	-T[=path]	Use alternate temporary directory
 	-q			Quiet (status to 'c.errors' instead of screen)
@@ -44,14 +46,14 @@ Linker options:
 	-b[=path]	Use an alternate "cstart"
 	-e<#>		Set edition of output module
 	-l=<path>	Link with a library file
-	-lg			Link with cgfx.l	(Graphics library)
-	-ll			Link with lexlib.l	(Lex helper library)
-	-ls			Link with sys.l		(System library)
+	-lg			Link with graphics library
+	-ll			Link with lex helper library
+	-ls			Link with system library
 	-M			Ask linker for linkage map
 	-m<##[K]>	Add additional memory needs for output module
 	-n=<name>	Set name of output module
 	-S			Ask linker for symbol table
-	-t			Link with clibt.l (Transcendental math library)
+	-t			Link with transcendental math library
 	-x			Use the work directory for the main library
 
 Authors

--- a/Source/Compiler/Lex/GNUmakefile
+++ b/Source/Compiler/Lex/GNUmakefile
@@ -1,23 +1,29 @@
-CFLAGS = -g -m32
+CC=clang
+YACC=../Yacc/yacc
+CFLAGS = -std=gnu89 -g -Dunix -DCNAME=\"$(CURDIR)/ncform\" \
+	-Wno-implicit-int -Wno-implicit-function-declaration \
+	-Wno-deprecated-non-prototype -Wno-int-conversion \
+	-Wno-return-mismatch -Wno-incompatible-pointer-types \
+	-Wno-format -Wno-pointer-sign
 
 all: lex
 
 lex: lmain.o y.tab.o sub1.o sub2.o header.o
-	cc $(CFLAGS) lmain.o y.tab.o sub1.o sub2.o header.o -o lex
+	$(CC) $(CFLAGS) lmain.o y.tab.o sub1.o sub2.o header.o -o lex
 
 smallex:
-	cc $(CFLAGS) -DSMALL lmain.c y.tab.c sub1.c sub2.c header.c -o smallex
+	$(CC) $(CFLAGS) -DSMALL lmain.c y.tab.c sub1.c sub2.c header.c -o smallex
 
 y.tab.c: parser.y
-	yacc parser.y
+	$(YACC) parser.y
 lmain.o:lmain.c ldefs.c once.c
-	cc -c $(CFLAGS) lmain.c
+	$(CC) -c $(CFLAGS) lmain.c
 sub1.o: sub1.c ldefs.c
-	cc -c $(CFLAGS) sub1.c
+	$(CC) -c $(CFLAGS) sub1.c
 sub2.o: sub2.c ldefs.c
-	cc -c $(CFLAGS) sub2.c
+	$(CC) -c $(CFLAGS) sub2.c
 header.o: header.c ldefs.c
-	cc -c $(CFLAGS) header.c
+	$(CC) -c $(CFLAGS) header.c
 
 install: all
 	install -s lex $(DESTDIR)/usr/local/bin

--- a/Source/Compiler/Lex/ldefs.c
+++ b/Source/Compiler/Lex/ldefs.c
@@ -1,4 +1,7 @@
 # include <stdio.h>
+# include <stdlib.h>
+# include <stdint.h>
+typedef intptr_t lexval_t;
 # define PP 1
 # ifdef unix
 
@@ -113,8 +116,8 @@ extern int prev;	/* previous input character */
 extern int pres;	/* present input character */
 extern int peek;	/* next input character */
 extern int *name;
-extern int *left;
-extern int *right;
+extern lexval_t *left;
+extern lexval_t *right;
 extern int *parent;
 extern char *nullstr;
 extern int tptr;
@@ -162,5 +165,5 @@ extern int optim;
 extern int *verify, *advance, *stoff;
 extern int scon;
 extern char *psave;
-extern char *calloc(), *myalloc();
+extern char *myalloc();
 extern int buserr(), segviol();

--- a/Source/Compiler/Lex/lmain.c
+++ b/Source/Compiler/Lex/lmain.c
@@ -193,11 +193,11 @@ free3core(){
 # endif
 char *myalloc(a,b)
   int a,b; {
-	register int i;
+	register char *i;
 	i = calloc(a, b);
 	if(i==0)
 		warning("OOPS - calloc returns a 0");
-	else if(i == -1){
+	else if(i == (char *)-1){
 # ifdef DEBUG
 		warning("calloc returns a -1");
 # endif

--- a/Source/Compiler/Lex/once.c
+++ b/Source/Compiler/Lex/once.c
@@ -59,8 +59,14 @@ char *pushptr = pushc;
 char *slptr = slist;
 
 # if (unix || ibm)
-char *cname = "/usr/local/share/lex/ncform";
-char *ratname = "/usr/local/share/lex/nrform";
+# ifndef CNAME
+# define CNAME "/usr/local/share/lex/ncform"
+# endif
+# ifndef RATNAME
+# define RATNAME "/usr/local/share/lex/nrform"
+# endif
+char *cname = CNAME;
+char *ratname = RATNAME;
 # endif
 
 # ifdef gcos
@@ -93,8 +99,8 @@ int chset;	/* 1 = char set modified */
 FILE *fin, *fother;
 int fptr;
 int *name;
-int *left;
-int *right;
+lexval_t *left;
+lexval_t *right;
 int *parent;
 char *nullstr;
 int tptr;

--- a/Source/Compiler/Lex/parser.y
+++ b/Source/Compiler/Lex/parser.y
@@ -9,6 +9,7 @@
 
 %{
 # include "ldefs.c"
+# define YYSTYPE lexval_t
 %}
 %%
 %{
@@ -237,10 +238,9 @@ yylex(){
 						sectbegin = TRUE;
 						i = treesize*(sizeof(*name)+sizeof(*left)+
 							sizeof(*right)+sizeof(*nullstr)+sizeof(*parent))+ALITTLEEXTRA;
-						c = myalloc(i,1);
-						if(c == 0)
+						p = myalloc(i,1);
+						if(p == 0)
 							error("Too little core for parse tree");
-						p = c;
 						cfree(p,i,1);
 						name = myalloc(treesize,sizeof(*name));
 						left = myalloc(treesize,sizeof(*left));

--- a/Source/Compiler/Lex/sub1.c
+++ b/Source/Compiler/Lex/sub1.c
@@ -388,7 +388,7 @@ gch(){
 	return(c);
 	}
 mn2(a,d,c)
-  int a,d,c;
+  int a; lexval_t d,c;
 	{
 	name[tptr] = a;
 	left[tptr] = d;
@@ -424,7 +424,7 @@ mn2(a,d,c)
 	return(tptr++);
 	}
 mn1(a,d)
-  int a,d;
+  int a; lexval_t d;
 	{
 	name[tptr] = a;
 	left[tptr] = d;
@@ -433,7 +433,7 @@ mn1(a,d)
 	switch(a){
 	case RCCL:
 	case RNCCL:
-		if(slength(d) == 0) nullstr[tptr] = TRUE;
+		if(slength((char *)d) == 0) nullstr[tptr] = TRUE;
 		break;
 	case STAR:
 	case QUEST:

--- a/Source/Compiler/Yacc/GNUmakefile
+++ b/Source/Compiler/Yacc/GNUmakefile
@@ -1,5 +1,8 @@
-CFLAGS=-O -g -m32 -DWORD32 \
-	-Wno-implicit-int -Wno-implicit-function-declaration
+CC=clang
+CFLAGS=-std=gnu89 -O -g -DWORD32 -DPARSER=\"$(CURDIR)/yaccpar\" \
+	-Wno-implicit-int -Wno-implicit-function-declaration \
+	-Wno-deprecated-non-prototype -Wno-int-conversion \
+	-Wno-return-mismatch -Wno-format
 head: yacc
 yacc: y1.o y2.o y3.o y4.o
 	$(CC) $(CFLAGS) -o yacc y?.o

--- a/Source/Compiler/Yacc/dextern.h
+++ b/Source/Compiler/Yacc/dextern.h
@@ -1,5 +1,6 @@
 # include <stdio.h>
 # include <ctype.h>
+# include <stdarg.h>
 # include "files.h"
 
 	/*  MANIFEST CONSTANT DEFINITIONS */
@@ -234,6 +235,7 @@ extern char *cstash();
 extern struct looksets *flset();
 extern char *symnam();
 extern char *writem();
+extern void error(char *, ...);
 
 	/* default settings for a number of macros */
 

--- a/Source/Compiler/Yacc/files.h
+++ b/Source/Compiler/Yacc/files.h
@@ -9,7 +9,9 @@
 #if defined(_OS9) || defined(_OSK) || defined(_OS9000)
 # define PARSER "/dd/lib/yaccpar"
 #else
+# ifndef PARSER
 # define PARSER "/usr/local/share/yacc/yaccpar"
+# endif
 #endif
 
 	/* basic size of the Yacc implementation */

--- a/Source/Compiler/Yacc/y1.c
+++ b/Source/Compiler/Yacc/y1.c
@@ -155,7 +155,8 @@ int zzacent = 0;
 int zzexcp = 0;
 int zzclose = 0;
 int zzsrconf = 0;
-int * zzmemsz = mem0;
+struct item itemstore[MEMSIZE];
+struct item *zzitemsz = itemstore;
 int zzrrconf = 0;
 
 summary(){ /* output the summary on the tty */
@@ -166,7 +167,7 @@ summary(){ /* output the summary on the tty */
 		fprintf( foutput, "%d/%d grammar rules, %d/%d states\n", nprod, NPROD, nstate, NSTATES );
 		fprintf( foutput, "%d shift/reduce, %d reduce/reduce conflicts reported\n", zzsrconf, zzrrconf );
 		fprintf( foutput, "%d/%d working sets used\n", zzcwp-wsets,  WSETSIZE );
-		fprintf( foutput, "memory: states,etc. %d/%d, parser %d/%d\n", zzmemsz-mem0, MEMSIZE,
+		fprintf( foutput, "memory: states,etc. %d/%d, parser %d/%d\n", zzitemsz-itemstore, MEMSIZE,
 			    memp-amem, ACTSIZE );
 		fprintf( foutput, "%d/%d distinct lookahead sets\n", nlset, LSETSIZE );
 		fprintf( foutput, "%d extra closures\n", zzclose - 2*nstate );
@@ -187,15 +188,20 @@ summary(){ /* output the summary on the tty */
 	}
 
 /* VARARGS1 */
-error(s,a1) char *s; { /* write out error comment */
-	
-	++nerrors;
-	fprintf( stderr, "\n fatal error: ");
-	fprintf( stderr, s,a1);
-	fprintf( stderr, ", line %d\n", lineno );
-	if( !fatfl ) return;
-	summary();
-	exit(1);
+void
+error(char *s, ...)
+{ /* write out error comment */
+		va_list ap;
+		
+		++nerrors;
+		va_start(ap, s);
+		fprintf( stderr, "\n fatal error: ");
+		vfprintf( stderr, s, ap);
+		fprintf( stderr, ", line %d\n", lineno );
+		va_end(ap);
+		if( !fatfl ) return;
+		summary();
+		exit(1);
 	}
 
 aryfil( v, n, c ) int *v,n,c; { /* set elements 0 through n-1 to c */
@@ -381,9 +387,9 @@ putitem( ptr, lptr )  int *ptr;  struct looksets *lptr; {
 	j->pitem = ptr;
 	if( !nolook ) j->look = flset( lptr );
 	pstate[nstate+1] = ++j;
-	if( (int *)j > zzmemsz ){
-		zzmemsz = (int *)j;
-		if( zzmemsz >=  &mem0[MEMSIZE] ) error( "out of state space" );
+	if( j > zzitemsz ){
+		zzitemsz = j;
+		if( zzitemsz >=  &itemstore[MEMSIZE] ) error( "out of state space" );
 		}
 	}
 
@@ -468,7 +474,7 @@ stagen(){ /* generate the states */
 	/* someday, alloc should be used to allocate all this stuff... for now, we
 	/* accept that if pointers don't fit in integers, there is a problem... */
 
-	pstate[0] = pstate[1] = (struct item *)mem;
+	pstate[0] = pstate[1] = itemstore;
 	aryfil( clset.lset, tbitset, 0 );
 	putitem( prdptr[0]+1, &clset );
 	tystate[0] = MUSTDO;

--- a/Source/Compiler/Yacc/y2.c
+++ b/Source/Compiler/Yacc/y2.c
@@ -64,7 +64,7 @@ int levprd[NPROD] ;	/* precedence levels for the productions */
 char *
 newext(file,ext) char *file, *ext; {
 	int len = strlen (file);
-	char *out = malloc (len + strlen(ext));
+	char *out = malloc (len + strlen(ext) + 1);
 	char *tmp;
 
 	strcpy (out, file);

--- a/Source/Libs/KLibc/GNUmakefile
+++ b/Source/Libs/KLibc/GNUmakefile
@@ -11,30 +11,30 @@ before-libc:
 	cd fmath; $(MAKE) $(MAKEFLAGS)
 	cd imath; $(MAKE) $(MAKEFLAGS)
 	cd sys.a; $(MAKE) $(MAKEFLAGS)
-#	cd sys.a; $(MAKE) $(MAKEFLAGS) cstart.r
+	cd sys.a; $(MAKE) $(MAKEFLAGS) cstart.o
 
 before-libct:
 	cd tmath; $(MAKE) $(MAKEFLAGS)
 
 clean:
-	cd lib.c; make $(MAKEFLAGS) clean
-	cd lib.a; make $(MAKEFLAGS) clean
-	cd fmath; make $(MAKEFLAGS) clean
-	cd imath; make $(MAKEFLAGS) clean
-	cd tmath; make $(MAKEFLAGS) clean
-	cd sys.a; make $(MAKEFLAGS) clean
-	-del libc.a
-	-del libct.a
+	cd lib.c; $(MAKE) $(MAKEFLAGS) clean
+	cd lib.a; $(MAKE) $(MAKEFLAGS) clean
+	cd fmath; $(MAKE) $(MAKEFLAGS) clean
+	cd imath; $(MAKE) $(MAKEFLAGS) clean
+	cd tmath; $(MAKE) $(MAKEFLAGS) clean
+	cd sys.a; $(MAKE) $(MAKEFLAGS) clean
+	rm -f libc.a libct.a
 
 libc.a: before-libc $(RFILES1) $(RFILE_F) $(RFILES2)
-	-del libc.a
-	lwar --merge libc.a $(RFILES1) $(RFILE_F) $(RFILES2)
+	rm -f libc.a
+	lwar -cm libc.a $(RFILES1) $(RFILE_F) $(RFILES2)
 
 libct.a: before-libct $(RFILES1) $(RFILE_T) $(RFILES2) before-libct
-	-del libct.a
-	lwar --merge libct.a $(RFILES1) $(RFILE_T) $(RFILES2)
+	rm -f libct.a
+	lwar -cm libct.a $(RFILES1) $(RFILE_T) $(RFILES2)
 
-install: clib.l clibt.l
-	copy -rw=$(LIB) clib.l clibt.l
+install: libc.a libct.a
+	install -m 0644 libc.a libct.a $(LIB)
+	install -m 0644 sys.a/cstart.o $(LIB)
 
 .PHONY: dummy before-libc before-libct

--- a/Source/Libs/KLibc/cmoc-alias-asm.awk
+++ b/Source/Libs/KLibc/cmoc-alias-asm.awk
@@ -1,0 +1,29 @@
+{
+    line = $0
+    tmp = line
+    sub(/^[ \t]*/, "", tmp)
+
+    if (tmp ~ /^_[a-z][A-Za-z0-9$_]*:/) {
+        alias = tmp
+        sub(/^_/, "", alias)
+        sub(/:.*/, ":", alias)
+        print alias
+        print line
+        next
+    }
+
+    print
+
+    if (tmp ~ /^_[a-z][A-Za-z0-9$_]*[ \t]+EXPORT([ \t].*)?$/) {
+        alias = tmp
+        sub(/^_/, "", alias)
+        print alias
+        next
+    }
+
+    if (tmp ~ /^_[a-z][A-Za-z0-9$_]*[ \t]*(;.*)?$/) {
+        alias = tmp
+        sub(/^_/, "", alias)
+        print alias
+    }
+}

--- a/Source/Libs/KLibc/cmoc-dedupe-asm.awk
+++ b/Source/Libs/KLibc/cmoc-dedupe-asm.awk
@@ -1,0 +1,25 @@
+{
+    line = $0
+    tmp = line
+    sub(/^[ \t]*/, "", tmp)
+
+    if (tmp ~ /^[A-Za-z_][A-Za-z0-9$_]*:[ \t]*(;.*)?$/) {
+        label = tmp
+        sub(/:.*/, "", label)
+        if (seen_label[label]++) next
+    }
+
+    if (tmp ~ /^[A-Za-z_][A-Za-z0-9$_]*[ \t]*(;.*)?$/) {
+        label = tmp
+        sub(/[ \t;].*/, "", label)
+        if (seen_label[label]++) next
+    }
+
+    if (tmp ~ /^[A-Za-z_][A-Za-z0-9$_]*[ \t]+EXPORT([ \t].*)?$/) {
+        symbol = tmp
+        sub(/[ \t]+EXPORT.*/, "", symbol)
+        if (seen_export[symbol]++) next
+    }
+
+    print line
+}

--- a/Source/Libs/KLibc/cmoc-inline-asm-to-dcc.awk
+++ b/Source/Libs/KLibc/cmoc-inline-asm-to-dcc.awk
@@ -1,0 +1,89 @@
+function symbol_char(ch) {
+    return ch ~ /^[A-Za-z0-9$_]$/
+}
+
+function symbol_start(ch) {
+    return ch ~ /^[A-Za-z_]$/
+}
+
+function dcc_symbol(line) {
+    gsub(/__iob/, "_iob", line)
+    gsub(/_fpmp/, "fpmp", line)
+    gsub(/_buf1/, "buf1", line)
+    gsub(/_dectbl/, "dectbl", line)
+    return line
+}
+
+function asmline(line) {
+    print "@" dcc_symbol(line)
+}
+
+BEGIN {
+    pending_asm_function = 0
+    in_asm_function = 0
+    in_asm_block = 0
+    asm_brace_depth = 0
+    function_brace_depth = 0
+}
+
+/^[ \t]*(__norts__[ \t]+asm|asm[ \t]+__norts__)[ \t]+/ {
+    pending_asm_function = 1
+    next
+}
+
+pending_asm_function {
+    if ($0 ~ /^[ \t]*[A-Za-z_][A-Za-z0-9$_]*[ \t]*\(/) {
+        name = $0
+        sub(/^[ \t]*/, "", name)
+        sub(/[ \t]*\(.*/, "", name)
+        asmline("_" name " EXPORT")
+        asmline(name " EXPORT")
+        asmline("_" name ":")
+        asmline(name ":")
+        pending_asm_function = 0
+        in_asm_function = 1
+        function_brace_depth = 0
+        next
+    }
+}
+
+in_asm_function {
+    if (!in_asm_block) {
+        if ($0 ~ /^[ \t]*asm[ \t]*$/ || $0 ~ /^[ \t]*asm[ \t]*\{/) {
+            in_asm_block = 1
+            asm_brace_depth = 0
+            if ($0 ~ /\{/) {
+                asm_brace_depth = 1
+            }
+        } else if ($0 ~ /\{/) {
+            function_brace_depth++
+        } else if ($0 ~ /\}/) {
+            if (function_brace_depth == 0) {
+                in_asm_function = 0
+            } else {
+                function_brace_depth--
+            }
+        }
+        next
+    }
+
+    if ($0 ~ /^[ \t]*\{[ \t]*$/) {
+        asm_brace_depth++
+        next
+    }
+
+    if ($0 ~ /^[ \t]*\}[ \t]*$/) {
+        asm_brace_depth--
+        if (asm_brace_depth <= 0) {
+            in_asm_block = 0
+        }
+        next
+    }
+
+    asmline($0)
+    next
+}
+
+{
+    print
+}

--- a/Source/Libs/KLibc/cmoc-rma2lw.sed
+++ b/Source/Libs/KLibc/cmoc-rma2lw.sed
@@ -1,18 +1,16 @@
-# translate name: into name EXPORT followed by name
-#s/^\([a-zA-Z_][a-zA-Z0-9$_]\+\):/\1 EXPORT\n\1/
-s/^\([a-zA-Z_][a-zA-Z0-9$_]*\):/\1 EXPORT\n\1/
-# translate sections
+# translate cmoc_os9 assembly for lwasm without auto-exporting every label.
+# cmoc_os9 sources already declare public symbols explicitly.
 s|^[\t ]*use[\t ][\t ]*/dd/defs/\(.*\)| use \1|
 s|^[\t ]*use[\t ][\t ]*\.\./include/\(.*\)| use \1|
 s|^[\t ]*use[\t ][\t ]*mdefs\.a| use mdefs.s|
 s|^[\t ]*use[\t ][\t ]*os9defs\.a| use os9.d|
 s/\([A-Za-z]\)\$\([A-Za-z]\)/\1_\2/g
 s/^[\t ]*psect.*/ SECTION code/
+s/^[\t ]*section[\t ][\t ]*rodata.*/ SECTION code/
 s/^[\t ]*vsect.*/ SECTION bss/
 s/^[\t ]*csect[\t ][\t ]*\(.*\)/ SECTION _constant\n org \1/
 s/^[\t ]*csect/ SECTION _constant/
 s/^[\t ]*endsect.*/ ENDSECT\n SECTION code/
 s/^[\t ]*ends.*/ ENDSECT\n SECTION code/
-# convert fail / warn directives
 s/^[\t ]*fail\(.*\)/ ERROR\1/
 s/^[\t ]*warn\(.*\)/ WARNING\1/

--- a/Source/Libs/KLibc/cmoc-strip-lseek-asm.awk
+++ b/Source/Libs/KLibc/cmoc-strip-lseek-asm.awk
@@ -1,0 +1,22 @@
+/_lseek[[:space:]]+EXPORT/ {
+    next
+}
+
+/^_lseek:/ {
+    skip = 1
+    next
+}
+
+skip && /^[[:space:]]+endsect/ {
+    skip = 0
+    print
+    next
+}
+
+skip {
+    next
+}
+
+{
+    print
+}

--- a/Source/Libs/KLibc/cmoc.make
+++ b/Source/Libs/KLibc/cmoc.make
@@ -1,29 +1,27 @@
 # disable built-in rules
 MAKEFLAGS+=-rR
 
-AFLAGS= --pragma=index0tonone,condundefzero,undefextern,dollarnotlocal,noforwardrefmax
-CFLAGS= -I/dd/defs -O2 -x c -nostdinc -nodefaultlibs --function-stack=0 --os9
+AFLAGS= --pragma=index0tonone,condundefzero,undefextern,dollarnotlocal,noforwardrefmax --includedir=$(DCC_DEFS)
+DCCFLAGS= -q
 
 # default top level to current dir
 TOP?=	$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 # our commands
 SED?=	sed
-CMOC?=	cmoc
+DCC?=	dcc
 LWASM?=	lwasm
 O2U?=	tr '\015' '\012'
 #our scripts
 DCCMOC	= $(TOP)/dccmoc.sed
 RMA2LW	= $(TOP)/rma2lw.sed
+DCC_DEFS?= $(TOP)/../../../Defs
 
-# implicit rules to compile with CMOC/lwasm
+# implicit rules to compile with DCC/lwasm
 %.s: %.a $(RMA2LW)
 	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@
 
-%.cp: %.c $(DCCMOC)
-	$(O2U) < $< | $(SED) -f $(DCCMOC) > $@
-
-%.s: %.cp
-	$(CMOC) $(CFLAGS) -S -o $@ $<
-
 %.o: %.s
 	$(LWASM) $(AFLAGS) --obj -o $@ $<
+
+%.o: %.c
+	$(DCC) -L $(DCCFLAGS) -r -f=$@ $<

--- a/Source/Libs/KLibc/cmoc.make
+++ b/Source/Libs/KLibc/cmoc.make
@@ -16,7 +16,17 @@ DCCMOC	= $(TOP)/dccmoc.sed
 RMA2LW	= $(TOP)/rma2lw.sed
 DCC_DEFS?= $(TOP)/../../../Defs
 
+ifneq ($(strip $(CMOC_OS9_DIR)),)
+CMOC_OS9_LIB	= $(CMOC_OS9_DIR)/lib
+DCC_DEFS	= $(CMOC_OS9_DIR)/include
+vpath %.as $(CMOC_OS9_LIB)
+vpath %.c $(CMOC_OS9_LIB)
+endif
+
 # implicit rules to compile with DCC/lwasm
+%.s: %.as $(RMA2LW)
+	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@
+
 %.s: %.a $(RMA2LW)
 	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@
 
@@ -24,4 +34,4 @@ DCC_DEFS?= $(TOP)/../../../Defs
 	$(LWASM) $(AFLAGS) --obj -o $@ $<
 
 %.o: %.c
-	$(DCC) -L $(DCCFLAGS) -r -f=$@ $<
+	CDEF=$(DCC_DEFS) $(DCC) -L $(DCCFLAGS) -r -f=$@ $<

--- a/Source/Libs/KLibc/cmoc.make
+++ b/Source/Libs/KLibc/cmoc.make
@@ -14,16 +14,28 @@ O2U?=	tr '\015' '\012'
 #our scripts
 DCCMOC	= $(TOP)/dccmoc.sed
 RMA2LW	= $(TOP)/rma2lw.sed
-DCC_DEFS?= $(TOP)/../../../Defs
+CMOC_RMA2LW	= $(TOP)/cmoc-rma2lw.sed
+CMOC_ALIAS	= $(TOP)/cmoc-alias-asm.awk
+CMOC_DEDUPE	= $(TOP)/cmoc-dedupe-asm.awk
 
-ifneq ($(strip $(CMOC_OS9_DIR)),)
-CMOC_OS9_LIB	= $(CMOC_OS9_DIR)/lib
-DCC_DEFS	= $(CMOC_OS9_DIR)/include
-vpath %.as $(CMOC_OS9_LIB)
-vpath %.c $(CMOC_OS9_LIB)
+ifeq ($(strip $(CMOC_OS9_DIR)),)
+ifneq ($(filter clean dskclean,$(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(error CMOC_OS9_DIR must point to the cmoc_os9 tree)
+endif
 endif
 
+CMOC_OS9_LIB	= $(CMOC_OS9_DIR)/lib
+DCC_DEFS	= $(CMOC_OS9_DIR)/include
+
 # implicit rules to compile with DCC/lwasm
+%.o: $(CMOC_OS9_LIB)/%.c
+	CDEF=$(DCC_DEFS) $(DCC) -L $(DCCFLAGS) -r -f=$@ $<
+
+%.o: $(CMOC_OS9_LIB)/%.as $(CMOC_RMA2LW) $(DCCMOC) $(CMOC_ALIAS) $(CMOC_DEDUPE)
+	$(O2U) < $< | $(SED) -f $(CMOC_RMA2LW) | $(SED) -f $(DCCMOC) | awk -f $(CMOC_ALIAS) | awk -f $(CMOC_DEDUPE) > $*.s
+	$(LWASM) $(AFLAGS) --obj -o $@ $*.s
+	$(RM) $*.s
+
 %.s: %.as $(RMA2LW)
 	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@
 

--- a/Source/Libs/KLibc/dcc-long-alias-asm.awk
+++ b/Source/Libs/KLibc/dcc-long-alias-asm.awk
@@ -1,0 +1,29 @@
+BEGIN {
+    public["atol"] = 1
+    public["fseek"] = 1
+    public["rewind"] = 1
+    public["ftell"] = 1
+    public["htol"] = 1
+    public["ltoa"] = 1
+    public["lseek"] = 1
+}
+
+{
+    label = $0
+    if (label ~ /^[A-Za-z][A-Za-z0-9$_]*:/) {
+        sub(/:.*/, "", label)
+        if (public[label]) {
+            print "_" label " EXPORT"
+            print "_" label ":"
+        }
+    } else if (label ~ /^[A-Za-z][A-Za-z0-9$_]*[ \t]+EXPORT([ \t].*)?$/) {
+        sub(/[ \t]+EXPORT.*/, "", label)
+        if (public[label])
+            print "_" label " EXPORT"
+    } else {
+        sub(/[ \t].*/, "", label)
+        if (public[label])
+            print "_" label
+    }
+    print
+}

--- a/Source/Libs/KLibc/dccmoc.sed
+++ b/Source/Libs/KLibc/dccmoc.sed
@@ -1,2 +1,11 @@
 s:^#[\t ]*asm:asm { /* #asm */:
 s:^#[\t ]*endasm:} /* #endasm */:
+
+# DCC keeps a few KLibc data names unprefixed or single-prefixed where CMOC
+# assembly expects CMOC's normal extra underscore.
+s/__iob/_iob/g
+s/__mtop/_mtop/g
+s/__stbot/_stbot/g
+s/__dumprof/_dumprof/g
+s/__tidyup/_tidyup/g
+s/_errno/errno/g

--- a/Source/Libs/KLibc/fmath/GNUmakefile
+++ b/Source/Libs/KLibc/fmath/GNUmakefile
@@ -1,0 +1,13 @@
+OFILES = cfloats.o
+
+all: cfloats.lib
+
+include ../cmoc.make
+
+cfloats.lib: $(OFILES)
+	lwar -c $@ $^
+
+clean:
+	rm -f cfloats.lib $(OFILES) *.s
+
+$(OFILES): GNUmakefile ../cmoc.make $(RMA2LW)

--- a/Source/Libs/KLibc/imath/GNUmakefile
+++ b/Source/Libs/KLibc/imath/GNUmakefile
@@ -4,11 +4,19 @@ OFILES2 = clbits.o clnegcompl.o clconvert.o clmove.o clincdec.o clshifts.o
 OFILES3 = clcommon.o ccmult.o ccmod.o ccdiv.o cshifts.o rpterr.o
 
 OFILES = $(OFILES1) $(OFILES2) $(OFILES3)
+DCC_LONG_HELPER_OFILES = clmul.o cldiv.o cludiv.o claddsub.o clcompare.o \
+	clbits.o clnegcompl.o clconvert.o clmove.o clincdec.o clshifts.o \
+	clcommon.o
 
 include ../cmoc.make
 
 math.lib: $(OFILES)
 	lwar -c $@ $^
+
+$(DCC_LONG_HELPER_OFILES): %.o: %.a $(RMA2LW)
+	$(O2U) < $< | $(SED) -f $(RMA2LW) > $*.s
+	$(LWASM) $(AFLAGS) --obj -o $@ $*.s
+	$(RM) $*.s
 
 clean:
 	-rm math.lib $(OFILES)

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -6,9 +6,9 @@ OFILES3 = setbuf.o fseek.o putc.o ftelldummy.o getc.o flshdummy.o setbase.o \
 OFILES4 = system.o reverse.o strings.o strcmp.o strlen.o strncpy.o strncat.o \
           strncmp.o strhcpy.o strtok.o strpbrk.o strspn.o index.o patmatch.o
 OFILES5 = stringsu.o strucmp.o strnucmp.o case.o strclr.o memccpy.o memchr.o \
-          memcmp.o memcpy.o memset.o atol.o atoi.o iob_data.o chcodes.o
+          memcmp.o memcpy.o memset.o atol.o atoi.o strtol.o iob_data.o chcodes.o
 OFILES6 = sleep.o setjmp.o strass.o realloc.o calloc.o memory.o rand.o
-OFILES7 = gs1.o gs2.o ss.o os_gs_ss.o
+OFILES7 = gs1.o gs2.o ss.o os_gs_ss.o dirseek.o l3tol.o ltol3.o ltoc3tol.o
 
 OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4) $(OFILES5) \
 	$(OFILES6) $(OFILES7)
@@ -29,6 +29,11 @@ printf.o: $(CMOC_OS9_LIB)/printf.c $(TOP)/cmoc-inline-asm-to-dcc.awk
 	$(O2U) < $< | awk -f $(TOP)/cmoc-inline-asm-to-dcc.awk > printf.dcc.c
 	CDEF=$(DCC_DEFS) $(DCC) -L $(DCCFLAGS) -r -f=$@ printf.dcc.c
 	$(RM) printf.dcc.c
+
+dirseek.o: dirseek.a $(RMA2LW)
+	$(O2U) < $< | $(SED) -f $(RMA2LW) > dirseek.s
+	$(LWASM) $(AFLAGS) --obj -o $@ dirseek.s
+	$(RM) dirseek.s
 
 main.lib: $(OFILES)
 	lwar -c $@ $^

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -8,19 +8,26 @@ OFILES4 = system.o reverse.o strings.o strcmp.o strlen.o strncpy.o strncat.o \
 OFILES5 = stringsu.o strucmp.o strnucmp.o case.o strclr.o memccpy.o memchr.o \
           memcmp.o memcpy.o memset.o atol.o atoi.o iob_data.o chcodes.o
 OFILES6 = sleep.o setjmp.o strass.o realloc.o calloc.o memory.o rand.o
-OFILES7 = gs1.o gs2.o ss1.o ss2.o ss3.o
+OFILES7 = gs.o ss.o os_gs_ss.o
 
 OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4) $(OFILES5) \
 	$(OFILES6) $(OFILES7)
 
 NFILES = atof.o scale.o ldexp.o frexp.o
 
+.DEFAULT_GOAL := main.lib
+
 include ../cmoc.make
+
+printf.o: $(CMOC_OS9_LIB)/printf.c $(TOP)/cmoc-inline-asm-to-dcc.awk
+	$(O2U) < $< | awk -f $(TOP)/cmoc-inline-asm-to-dcc.awk > printf.dcc.c
+	CDEF=$(DCC_DEFS) $(DCC) -L $(DCCFLAGS) -r -f=$@ printf.dcc.c
+	$(RM) printf.dcc.c
 
 main.lib: $(OFILES)
 	lwar -c $@ $^
 
 clean:
-	-rm *.o *.s *.cp
+	-rm main.lib *.o *.s *.cp
 
 $(OFILES): GNUmakefile $(DCCMOC) $(RMA2LW)

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -14,10 +14,16 @@ OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4) $(OFILES5) \
 	$(OFILES6) $(OFILES7)
 
 NFILES = atof.o scale.o ldexp.o frexp.o
+DCC_LONG_ABI_OFILES = atol.o fseek.o htol.o ltoa.o
 
 .DEFAULT_GOAL := main.lib
 
 include ../cmoc.make
+
+$(DCC_LONG_ABI_OFILES): %.o: %.a $(RMA2LW) $(TOP)/dcc-long-alias-asm.awk
+	$(O2U) < $< | $(SED) -f $(RMA2LW) | awk -f $(TOP)/dcc-long-alias-asm.awk > $*.s
+	$(LWASM) $(AFLAGS) --obj -o $@ $*.s
+	$(RM) $*.s
 
 printf.o: $(CMOC_OS9_LIB)/printf.c $(TOP)/cmoc-inline-asm-to-dcc.awk
 	$(O2U) < $< | awk -f $(TOP)/cmoc-inline-asm-to-dcc.awk > printf.dcc.c

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -8,7 +8,7 @@ OFILES4 = system.o reverse.o strings.o strcmp.o strlen.o strncpy.o strncat.o \
 OFILES5 = stringsu.o strucmp.o strnucmp.o case.o strclr.o memccpy.o memchr.o \
           memcmp.o memcpy.o memset.o atol.o atoi.o iob_data.o chcodes.o
 OFILES6 = sleep.o setjmp.o strass.o realloc.o calloc.o memory.o rand.o
-OFILES7 = gs.o ss.o os_gs_ss.o
+OFILES7 = gs1.o gs2.o ss.o os_gs_ss.o
 
 OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4) $(OFILES5) \
 	$(OFILES6) $(OFILES7)

--- a/Source/Libs/KLibc/lib.a/GNUmakefile
+++ b/Source/Libs/KLibc/lib.a/GNUmakefile
@@ -1,4 +1,4 @@
-OFILES1 = swab.o pwcryp.o bsearch.o dirutil.o errmsg.o prgname.o \
+OFILES1 = swab.o pwcryp.o bsearch.o qsort.o dirutil.o errmsg.o prgname.o \
           datmods.o devtyp.o skip.o sets.o pflinit.o
 OFILES2 = fopen.o puts.o gets.o mktemp.o fread.o fwrite.o printf.o
 OFILES3 = setbuf.o fseek.o putc.o ftelldummy.o getc.o flshdummy.o setbase.o \

--- a/Source/Libs/KLibc/lib.a/dirseek.a
+++ b/Source/Libs/KLibc/lib.a/dirseek.a
@@ -1,0 +1,39 @@
+ psect dirseek_a,0,0,1,0,0
+
+* seekdir(dirp, loc)
+* DIR   *dirp;
+* long  loc;
+*    {
+*    lseek(dirp->dd_fd, loc, 0);
+*    }
+
+seekdir:
+ clra
+ clrb
+ pshs D from front
+ ldd 8,S ls word
+ pshs D
+ ldd 8,S ms word
+ bra telldir1
+
+*
+* long
+* telldir(dirp)
+* DIR   *dirp;
+*    {
+*    return (lseek(dirp->dd_fd, 0L, 1));
+*    }
+
+telldir:
+ ldd #1
+ pshs D from here
+ clrb
+ pshs D zero offset
+telldir1 pshs D
+ ldd [8,S] fp
+ pshs D
+ lbsr lseek
+ leas 8,s
+ rts X points to ret val
+
+ endsect

--- a/Source/Libs/KLibc/lib.a/qsort.c
+++ b/Source/Libs/KLibc/lib.a/qsort.c
@@ -1,0 +1,36 @@
+int qsort(base, nmemb, size, compar)
+char *base;
+unsigned nmemb;
+unsigned size;
+int (*compar)();
+{
+    unsigned i, j, k;
+    char *a, *b, *pa, *pb;
+    char tmp;
+
+    if (base == 0 || nmemb < 2 || size == 0)
+        return 0;
+
+    for (i = 1; i < nmemb; ++i)
+      {
+        j = i;
+        while (j > 0)
+          {
+            a = base + ((j - 1) * size);
+            b = base + (j * size);
+            if ((*compar)(a, b) <= 0)
+                break;
+
+            pa = a;
+            pb = b;
+            for (k = 0; k < size; ++k)
+              {
+                tmp = *pa;
+                *pa++ = *pb;
+                *pb++ = tmp;
+              }
+            --j;
+          }
+      }
+    return 0;
+}

--- a/Source/Libs/KLibc/lib.c/GNUmakefile
+++ b/Source/Libs/KLibc/lib.c/GNUmakefile
@@ -1,9 +1,7 @@
 OFILES	= prof.o pwent.o getopt.o adump.o defdrive.o popen.o \
  asctime.o ctime.o systime.o time.o localtime.o mktime.o isleap.o timevars.o
 
-DFILES	= dbg.o getsp.o
-
-all: cstuff.lib dbg.lib
+all: cstuff.lib
 
 include ../cmoc.make
 
@@ -12,10 +10,7 @@ CFLAGS += -I../defs
 cstuff.lib: $(OFILES)
 	lwar -c $@ $^
 
-dbg.lib: $(DFILES)
-	lwar -c $@ $^
-
 clean:
-	-rm *.o *.s *.cp
+	rm -f cstuff.lib dbg.lib *.o *.s *.cp *.list *.map c.errors
 
 $(OFILES): GNUmakefile $(DCCMOC) $(RMA2LW)

--- a/Source/Libs/KLibc/lib.c/GNUmakefile
+++ b/Source/Libs/KLibc/lib.c/GNUmakefile
@@ -1,5 +1,5 @@
 OFILES	= prof.o pwent.o getopt.o adump.o defdrive.o popen.o \
- asctime.o ctime.o systime.o time.o localtime.o mktime.o isleap.o timevars.o
+ asctime.o ctime.o time.o localtime.o mktime.o isleap.o timevars.o
 
 all: cstuff.lib
 

--- a/Source/Libs/KLibc/lib.c/GNUmakefile
+++ b/Source/Libs/KLibc/lib.c/GNUmakefile
@@ -10,6 +10,9 @@ CFLAGS += -I../defs
 cstuff.lib: $(OFILES)
 	lwar -c $@ $^
 
+time.o: time.c
+	CDEF=$(DCC_DEFS) $(DCC) -L $(DCCFLAGS) -r -f=$@ $<
+
 clean:
 	rm -f cstuff.lib dbg.lib *.o *.s *.cp *.list *.map c.errors
 

--- a/Source/Libs/KLibc/lib.c/time.c
+++ b/Source/Libs/KLibc/lib.c/time.c
@@ -1,8 +1,18 @@
 #include <time.h>
 
+struct sgtbuf {
+	unsigned char t_year;
+	unsigned char t_month;
+	unsigned char t_day;
+	unsigned char t_hour;
+	unsigned char t_minute;
+	unsigned char t_second;
+};
+
 extern unsigned _mdays[];
 extern int _isleap();
 extern unsigned _leaps();
+extern time_t cvtime();
 
 time_t
 time (arg)

--- a/Source/Libs/KLibc/rma2lw.sed
+++ b/Source/Libs/KLibc/rma2lw.sed
@@ -1,13 +1,15 @@
 # translate name: into name EXPORT followed by name
 #s/^\([a-zA-Z_][a-zA-Z0-9$_]\+\):/\1 EXPORT\n\1/
-s/^\([a-zA-Z_][a-zA-Z0-9$_]\+\):/_\1 EXPORT\n\1 EXPORT\n_\1\n\1/
+s/^\([a-zA-Z_][a-zA-Z0-9$_]*\):/\1 EXPORT\n\1/
 # translate sections
-s/^[\t ]\+psect.*/ SECTION code/
-s/^[\t ]\+vsect.*/ SECTION bss/
-s/^[\t ]\+csect[\t ]\+\(.*\)/ SECTION _constant\n org \1/
-s/^[\t ]\+csect/ SECTION _constant/
-s/^[\t ]\+endsect.*/ ENDSECT\n SECTION code/
-s/^[\t ]\+ends.*/ ENDSECT\n SECTION code/
+s|^[\t ]*use[\t ][\t ]*/dd/defs/\(.*\)| use \1|
+s|^[\t ]*use[\t ][\t ]*mdefs\.a| use mdefs.s|
+s/^[\t ]*psect.*/ SECTION code/
+s/^[\t ]*vsect.*/ SECTION bss/
+s/^[\t ]*csect[\t ][\t ]*\(.*\)/ SECTION _constant\n org \1/
+s/^[\t ]*csect/ SECTION _constant/
+s/^[\t ]*endsect.*/ ENDSECT\n SECTION code/
+s/^[\t ]*ends.*/ ENDSECT\n SECTION code/
 # convert fail / warn directives
-s/^[\t ]\+fail\(.*\)/ ERROR\1/
-s/^[\t ]\+warn\(.*\)/ WARNING\1/
+s/^[\t ]*fail\(.*\)/ ERROR\1/
+s/^[\t ]*warn\(.*\)/ WARNING\1/

--- a/Source/Libs/KLibc/rma2lw.sed
+++ b/Source/Libs/KLibc/rma2lw.sed
@@ -7,6 +7,7 @@ s|^[\t ]*use[\t ][\t ]*\.\./include/\(.*\)| use \1|
 s|^[\t ]*use[\t ][\t ]*mdefs\.a| use mdefs.s|
 s|^[\t ]*use[\t ][\t ]*os9defs\.a| use os9.d|
 s/\([A-Za-z]\)\$\([A-Za-z]\)/\1_\2/g
+s/SS\.\([A-Za-z][A-Za-z0-9]*\)/SS_\1/g
 s/^[\t ]*psect.*/ SECTION code/
 s/^[\t ]*vsect.*/ SECTION bss/
 s/^[\t ]*csect[\t ][\t ]*\(.*\)/ SECTION _constant\n org \1/

--- a/Source/Libs/KLibc/sys.a/GNUmakefile
+++ b/Source/Libs/KLibc/sys.a/GNUmakefile
@@ -1,5 +1,5 @@
 OFILES1 = abort.o signal.o chown.o chmod.o stat.o access.o create.o
-OFILES2 = open.o read.o write.o io.o misc.o mod.o dir.o brk.o ibrk.o sbrk.o mem.o
+OFILES2 = open.o read.o write.o io.o lseek.o misc.o mod.o dir.o brk.o ibrk.o sbrk.o mem.o
 OFILES3 = time.o process.o id.o intercept.o syscall.o syscommon.o
 OFILES4 = cfinish.o profdummy.o tidyup.o
 
@@ -19,3 +19,13 @@ $(OFILES) cstart.o root.o: GNUmakefile ../cmoc.make $(RMA2LW)
 
 cstart.s: cstart-lw.a $(RMA2LW)
 	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@
+
+lseek.o: lseek.a $(RMA2LW) $(TOP)/dcc-long-alias-asm.awk
+	$(O2U) < $< | $(SED) -f $(RMA2LW) | awk -f $(TOP)/dcc-long-alias-asm.awk > lseek.s
+	$(LWASM) $(AFLAGS) --obj -o $@ lseek.s
+	$(RM) lseek.s
+
+io.o: $(CMOC_OS9_LIB)/io.as $(CMOC_RMA2LW) $(DCCMOC) $(CMOC_ALIAS) $(CMOC_DEDUPE) $(TOP)/cmoc-strip-lseek-asm.awk
+	$(O2U) < $< | awk -f $(TOP)/cmoc-strip-lseek-asm.awk | $(SED) -f $(CMOC_RMA2LW) | $(SED) -f $(DCCMOC) | awk -f $(CMOC_ALIAS) | awk -f $(CMOC_DEDUPE) > io.s
+	$(LWASM) $(AFLAGS) --obj -o $@ io.s
+	$(RM) io.s

--- a/Source/Libs/KLibc/sys.a/GNUmakefile
+++ b/Source/Libs/KLibc/sys.a/GNUmakefile
@@ -25,6 +25,11 @@ lseek.o: lseek.a $(RMA2LW) $(TOP)/dcc-long-alias-asm.awk
 	$(LWASM) $(AFLAGS) --obj -o $@ lseek.s
 	$(RM) lseek.s
 
+time.o: time.a $(RMA2LW)
+	$(O2U) < $< | $(SED) -f $(RMA2LW) > time.s
+	$(LWASM) $(AFLAGS) --obj -o $@ time.s
+	$(RM) time.s
+
 io.o: $(CMOC_OS9_LIB)/io.as $(CMOC_RMA2LW) $(DCCMOC) $(CMOC_ALIAS) $(CMOC_DEDUPE) $(TOP)/cmoc-strip-lseek-asm.awk
 	$(O2U) < $< | awk -f $(TOP)/cmoc-strip-lseek-asm.awk | $(SED) -f $(CMOC_RMA2LW) | $(SED) -f $(DCCMOC) | awk -f $(CMOC_ALIAS) | awk -f $(CMOC_DEDUPE) > io.s
 	$(LWASM) $(AFLAGS) --obj -o $@ io.s

--- a/Source/Libs/KLibc/sys.a/GNUmakefile
+++ b/Source/Libs/KLibc/sys.a/GNUmakefile
@@ -1,5 +1,5 @@
 OFILES1 = abort.o signal.o chown.o chmod.o stat.o access.o create.o
-OFILES2 = open.o read.o write.o lseek.o misc.o mod.o dir.o brk.o ibrk.o sbrk.o mem.o
+OFILES2 = open.o read.o write.o io.o misc.o mod.o dir.o brk.o ibrk.o sbrk.o mem.o
 OFILES3 = time.o process.o id.o intercept.o syscall.o syscommon.o
 OFILES4 = cfinish.o profdummy.o tidyup.o
 

--- a/Source/Libs/KLibc/sys.a/GNUmakefile
+++ b/Source/Libs/KLibc/sys.a/GNUmakefile
@@ -1,0 +1,21 @@
+OFILES1 = abort.o signal.o chown.o chmod.o stat.o access.o create.o
+OFILES2 = open.o read.o write.o lseek.o misc.o mod.o dir.o brk.o ibrk.o sbrk.o mem.o
+OFILES3 = time.o process.o id.o intercept.o syscall.o syscommon.o
+OFILES4 = cfinish.o profdummy.o tidyup.o
+
+OFILES = $(OFILES1) $(OFILES2) $(OFILES3) $(OFILES4)
+
+all: syslib.lib cstart.o
+
+include ../cmoc.make
+
+syslib.lib: $(OFILES)
+	lwar -c $@ $^
+
+clean:
+	rm -f syslib.lib cstart.o root.o *.o *.s
+
+$(OFILES) cstart.o root.o: GNUmakefile ../cmoc.make $(RMA2LW)
+
+cstart.s: cstart-lw.a $(RMA2LW)
+	$(O2U) < $< | $(SED) -f $(RMA2LW) > $@

--- a/Source/Libs/KLibc/sys.a/chmod.a
+++ b/Source/Libs/KLibc/sys.a/chmod.a
@@ -23,13 +23,13 @@ chmod:
  cmpy #0 super-user?
  beq chmod10 yes, he can do it
  ldb #E$FNA prime for error
- cmpy FD.Own,x user's own file?
+ cmpy 1,x user's own file?
  orcc #Carry prime the carry
  bne chexit no, return error
 
 chmod10
  ldb Bufsize+12,s get the new attributes
- stb FD.Att,x update FD
+ stb 0,x update FD attributes
  puls a,y restore path number
  ldb #SS.FD write FD code
  os9 I$SetStt write the FD
@@ -47,7 +47,7 @@ chexit
 * Bufsize buffer is at 2,s
 *
 openfile
- lda #Write. access mode
+ lda #2 write access mode
  ldx Bufsize+8,s address of name
  os9 I$Open open the file
  bcc openf10 exit if error

--- a/Source/Libs/KLibc/sys.a/chown.a
+++ b/Source/Libs/KLibc/sys.a/chown.a
@@ -26,7 +26,7 @@ chown:
 
  pshs a save path number
  ldd Bufsize+9,s get the new owner id
- std FD.Own,x modify the FD
+ std 1,x modify the FD owner
  puls a restore path number
  ldb #SS.FD write FD code
  os9 I$SetStt write the FD
@@ -44,7 +44,7 @@ chexit
 * Bufsize buffer is at 2,s
 *
 openfile
- lda #Write. access mode
+ lda #2 write access mode
  ldx Bufsize+8,s address of name
  os9 I$Open open the file
  bcc openf10 exit if error

--- a/Source/Libs/KLibc/sys.a/mod.a
+++ b/Source/Libs/KLibc/sys.a/mod.a
@@ -2,12 +2,6 @@
 * Module access system calls
 *
 
-shiftla macro
- rept \1
- lsla
- endr
- endm
-
  use /dd/defs/os9defs.a
  psect mod_a,0,0,1,0,0
 
@@ -15,7 +9,10 @@ shiftla macro
 modlink: pshs y,u save environment
  ldx 6,s get module name pointer
  lda 9,s get type
- shiftla 4 shift to m.s nibble
+ lsla shift to m.s nibble
+ lsla
+ lsla
+ lsla
  ora 11,s and language
 
  os9 F$Link call os9
@@ -32,7 +29,10 @@ modcom
 modload: pshs y,u save environment
  ldx 6,s get module name pointer
  lda 9,s get type
- shiftla 4
+ lsla
+ lsla
+ lsla
+ lsla
  ora 11,s and type
 
  os9 F$Load call os9

--- a/Source/Libs/KLibc/tmath/GNUmakefile
+++ b/Source/Libs/KLibc/tmath/GNUmakefile
@@ -1,0 +1,16 @@
+OFILES = daddsub.o hyp.o dser.o trnser.o trig.o log.o ddiv.o \
+	dsqrt.o dtype.o dmul.o dinc.o dcmpr.o
+
+all: trans.lib
+
+include ../cmoc.make
+
+trans.lib: $(OFILES)
+	lwar -c $@ $^
+
+clean:
+	rm -f trans.lib $(OFILES) *.s
+
+$(OFILES): GNUmakefile ../cmoc.make $(RMA2LW)
+
+daddsub.s hyp.s dser.s trnser.s trig.s log.s ddiv.s dsqrt.s dmul.s dinc.s: mdefs.s

--- a/install-dcc-macos.sh
+++ b/install-dcc-macos.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+PREFIX=${PREFIX:-"$HOME/dcc"}
+BINDIR=${BINDIR:-"$PREFIX/bin"}
+DCCDIR=${DCCDIR:-"$PREFIX/share/dcc"}
+DEFDIR=${DEFDIR:-"$DCCDIR/defs"}
+LIBDIR=${LIBDIR:-"$DCCDIR/lib"}
+CC=${CC:-clang}
+MAKE=${MAKE:-/usr/bin/gnumake}
+
+if [ ! -x "$MAKE" ]; then
+	echo "error: GNU make not found at $MAKE" >&2
+	echo "Install it with Homebrew, or run with MAKE=/path/to/gmake." >&2
+	exit 1
+fi
+
+if ! command -v "$CC" >/dev/null 2>&1; then
+	echo "error: compiler '$CC' not found on PATH" >&2
+	exit 1
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+	echo "error: this installer is intended for macOS" >&2
+	exit 1
+fi
+
+run_make() {
+	dir=$1
+	shift
+	( cd "$ROOT/$dir" && "$MAKE" "$@" )
+}
+
+install_file() {
+	mode=$1
+	src=$2
+	dst=$3
+	install -m "$mode" "$src" "$dst"
+}
+
+mkdir -p "$BINDIR" "$DCCDIR" "$DEFDIR" "$LIBDIR"
+
+COMMON_WARN="-Wno-implicit-int -Wno-implicit-function-declaration -Wno-deprecated-non-prototype -Wno-int-conversion -Wno-return-mismatch"
+
+echo "Building dcpp"
+run_make Source/Compiler/CPP clean
+run_make Source/Compiler/CPP \
+	CC="$CC" \
+	ARCH= \
+	CFLAGS="-std=gnu89 -g -fsigned-char -Dunix -DUNIX -DDCC -DDEBUG -DDEFDIR=\\\"$DEFDIR\\\" -Wall -Wno-incompatible-pointer-types $COMMON_WARN -Wno-parentheses -Wno-return-type -Wno-pointer-to-int-cast" \
+	LDFLAGS="-g"
+
+echo "Building dcc68"
+run_make Source/Compiler/CC09 clean
+run_make Source/Compiler/CC09 \
+	CC="$CC" \
+	DCCDIR="$DCCDIR" \
+	ARCH= \
+	CFLAGS="-std=gnu89 -g -fsigned-char -DFUNCNAME -DUNIX -DPTREE -DPROF -DREGCONTS -DCKEYSFILE=\\\"$DCCDIR/ckeys\\\" -Wall -Wno-incompatible-pointer-types $COMMON_WARN -Wno-parentheses -Wno-return-type -Wno-char-subscripts -Wno-format -Wno-pointer-to-int-cast" \
+	LDFLAGS="-g -lm"
+
+echo "Building dco68"
+run_make Source/Compiler/COpt clean
+run_make Source/Compiler/COpt \
+	CC="$CC" \
+	DCCDIR="$DCCDIR" \
+	CFLAGS="-std=gnu11 -g -fsigned-char -DUNIX -DDEBUG -DCONFDIR=\\\"$DCCDIR\\\" -Wall -Wno-char-subscripts -Wno-incompatible-pointer-types $COMMON_WARN -Wno-parentheses -Wno-return-type" \
+	LDFLAGS="-g"
+
+echo "Building dcc"
+run_make Source/Compiler/DCC clean
+run_make Source/Compiler/DCC \
+	CC="$CC" \
+	CFLAGS="-std=gnu89 -g -fsigned-char -DDCC_DEFDRIVE=\\\"$DCCDIR\\\" -DDCC_LIBDIR=\\\"/lib/\\\" $COMMON_WARN -Wno-incompatible-pointer-types -Wno-return-type" \
+	LFLAGS="-g"
+
+echo "Installing binaries into $BINDIR"
+install_file 0755 "$ROOT/Source/Compiler/CPP/dcpp" "$BINDIR/dcpp"
+install_file 0755 "$ROOT/Source/Compiler/CC09/dcc68" "$BINDIR/dcc68"
+install_file 0755 "$ROOT/Source/Compiler/COpt/dco68" "$BINDIR/dco68"
+install_file 0755 "$ROOT/Source/Compiler/DCC/dcc" "$BINDIR/dcc"
+
+echo "Installing support files into $DCCDIR"
+install_file 0600 "$ROOT/Source/Compiler/CC09/ckeys" "$DCCDIR/ckeys"
+install_file 0644 "$ROOT/Source/Compiler/COpt/level1.patterns" "$DCCDIR/level1.patterns"
+install_file 0644 "$ROOT/Source/Compiler/COpt/level2.patterns" "$DCCDIR/level2.patterns"
+install_file 0644 "$ROOT/Source/Compiler/DCC/dcc.hlp" "$DCCDIR/dcc.hlp"
+
+echo "Installing target include files into $DEFDIR"
+( cd "$ROOT/Defs" && find . -type d -exec mkdir -p "$DEFDIR/{}" \; )
+( cd "$ROOT/Defs" && find . -type f -exec install -m 0644 "{}" "$DEFDIR/{}" \; )
+
+echo "Building LWTOOLS target library files"
+( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" clean )
+( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" )
+
+echo "Installing LWTOOLS target library files into $LIBDIR"
+rm -f "$LIBDIR"/cstart.r "$LIBDIR"/clib.l "$LIBDIR"/clibt.l "$LIBDIR"/sys.l "$LIBDIR"/dbg.l "$LIBDIR"/cgfx.l "$LIBDIR"/lexlib.l "$LIBDIR"/malloc.r "$LIBDIR"/libdbg.a "$LIBDIR"/level1.patterns "$LIBDIR"/level2.patterns
+install_file 0644 "$ROOT/Source/Libs/KLibc/libc.a" "$LIBDIR/libc.a"
+install_file 0644 "$ROOT/Source/Libs/KLibc/libct.a" "$LIBDIR/libct.a"
+install_file 0644 "$ROOT/Source/Libs/KLibc/sys.a/cstart.o" "$LIBDIR/cstart.o"
+
+echo
+echo "Installed DCC tools:"
+echo "  $BINDIR/dcc"
+echo "  $BINDIR/dcpp"
+echo "  $BINDIR/dcc68"
+echo "  $BINDIR/dco68"
+echo
+echo "Installed DCC support files:"
+echo "  $DCCDIR"
+echo "  $DEFDIR"
+echo "  $LIBDIR"
+echo
+echo "Make sure this directory is on PATH:"
+echo "  export PATH=\"$BINDIR:\$PATH\""
+echo
+echo "Use 'dcc file.c' to build and link through lwasm/lwlink. Use 'dcc -R file.c' for the legacy RMA/RLINK flow."
+echo "Use 'dcc -a file.c' to stop after generated assembly output."

--- a/install-dcc-macos.sh
+++ b/install-dcc-macos.sh
@@ -10,6 +10,16 @@ DEFDIR=${DEFDIR:-"$DCCDIR/defs"}
 LIBDIR=${LIBDIR:-"$DCCDIR/lib"}
 CC=${CC:-clang}
 MAKE=${MAKE:-/usr/bin/gnumake}
+CMOC_OS9_DIR=${CMOC_OS9_DIR:-}
+
+if [ -z "$CMOC_OS9_DIR" ]; then
+	for candidate in "$ROOT/../coco-shelf/cmoc_os9" "$ROOT/../cmoc_os9"; do
+		if [ -d "$candidate/include" ] && [ -d "$candidate/lib" ]; then
+			CMOC_OS9_DIR=$candidate
+			break
+		fi
+	done
+fi
 
 if [ ! -x "$MAKE" ]; then
 	echo "error: GNU make not found at $MAKE" >&2
@@ -19,6 +29,12 @@ fi
 
 if ! command -v "$CC" >/dev/null 2>&1; then
 	echo "error: compiler '$CC' not found on PATH" >&2
+	exit 1
+fi
+
+if [ -z "$CMOC_OS9_DIR" ] || [ ! -d "$CMOC_OS9_DIR/include" ] || [ ! -d "$CMOC_OS9_DIR/lib" ]; then
+	echo "error: CMOC_OS9_DIR must point to a cmoc_os9 tree with include/ and lib/" >&2
+	echo "Example: CMOC_OS9_DIR=/path/to/coco-shelf/cmoc_os9 ./install-dcc-macos.sh" >&2
 	exit 1
 fi
 
@@ -89,12 +105,12 @@ install_file 0644 "$ROOT/Source/Compiler/COpt/level2.patterns" "$DCCDIR/level2.p
 install_file 0644 "$ROOT/Source/Compiler/DCC/dcc.hlp" "$DCCDIR/dcc.hlp"
 
 echo "Installing target include files into $DEFDIR"
-( cd "$ROOT/Defs" && find . -type d -exec mkdir -p "$DEFDIR/{}" \; )
-( cd "$ROOT/Defs" && find . -type f -exec install -m 0644 "{}" "$DEFDIR/{}" \; )
+( cd "$CMOC_OS9_DIR/include" && find . -type d -exec mkdir -p "$DEFDIR/{}" \; )
+( cd "$CMOC_OS9_DIR/include" && find . -type f -exec install -m 0644 "{}" "$DEFDIR/{}" \; )
 
 echo "Building LWTOOLS target library files"
-( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" clean )
-( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" )
+( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" CMOC_OS9_DIR="$CMOC_OS9_DIR" clean )
+( cd "$ROOT/Source/Libs/KLibc" && PATH="$BINDIR:$PATH" "$MAKE" CMOC_OS9_DIR="$CMOC_OS9_DIR" )
 
 echo "Installing LWTOOLS target library files into $LIBDIR"
 rm -f "$LIBDIR"/cstart.r "$LIBDIR"/clib.l "$LIBDIR"/clibt.l "$LIBDIR"/sys.l "$LIBDIR"/dbg.l "$LIBDIR"/cgfx.l "$LIBDIR"/lexlib.l "$LIBDIR"/malloc.r "$LIBDIR"/libdbg.a "$LIBDIR"/level1.patterns "$LIBDIR"/level2.patterns
@@ -113,6 +129,7 @@ echo "Installed DCC support files:"
 echo "  $DCCDIR"
 echo "  $DEFDIR"
 echo "  $LIBDIR"
+echo "  cmoc_os9 source: $CMOC_OS9_DIR"
 echo
 echo "Make sure this directory is on PATH:"
 echo "  export PATH=\"$BINDIR:\$PATH\""


### PR DESCRIPTION
## Summary

This updates DCC so the modern native build and default target workflow use LWTOOLS (`lwasm`/`lwlink`) instead of the legacy `rma`/`rlink` toolchain, while retaining a compatibility switch for the old flow.

The main behavioral change is that `dcc file.c` now emits LWTOOLS-compatible objects and links through `lwlink` by default. Existing `-L` usage remains accepted, and `-R` selects the legacy RMA/RLINK path.

## What Changed

- Make LWTOOLS the default DCC backend
  - Add `lwasm`/`lwlink` driver support in `dcc`.
  - Pass `-L` through to `dcc68` when generating LWTOOLS-compatible assembly.
  - Treat `.o` inputs as already-built LWTOOLS objects instead of assuming `.r` intermediates.
  - Link internally through `lwlink` so package makefiles can call `dcc` end-to-end.
  - Preserve legacy RMA/RLINK via new `-R` option.

- Improve native macOS buildability
  - Clean up host compiler assumptions and prototypes across the compiler tools.
  - Fix Unix `system()` status handling so failed child commands are reported correctly.
  - Update GNUmakefiles and warning flags where needed for current clang/GNU make builds.

- Add a localized macOS install script
  - New `install-dcc-macos.sh` builds and installs into `$HOME/dcc` by default.
  - Installs compiler binaries, definitions, help, startup object, and target libraries.
  - Keeps installation out of `/usr/local` unless the caller overrides `PREFIX`.

- Build target libraries for the LWTOOLS path
  - Add GNUmakefiles for KLibc sub-libraries built with `lwasm`/`lwar`.
  - Update the RMA-to-LWTOOLS conversion flow.
  - Fix `chmod`/`chown` assembly issues exposed by LWTOOLS.
  - Add `qsort()` to `libc.a` for packages that expect it.

## Compatibility Notes

- `dcc file.c` now defaults to LWTOOLS output and linking.
- `dcc -L file.c` still works and is effectively explicit-default mode.
- `dcc -R file.c` requests the old RMA/RLINK flow.
- `.r` assumptions are intentionally removed from the default path; `.o` is the default object suffix for LWTOOLS builds.

## Validation Performed

- Built the compiler tools natively on macOS with clang.
- Installed into `$HOME/dcc` using the new install script.
- Rebuilt and installed the LWTOOLS target libraries.
- Used the installed `dcc` to build NitrOS-9 third-party packages including `ed`, `uemacs`, and `uucpbb` through the new default LWTOOLS flow.

## Review Focus

The biggest area to review is the default backend flip in `Source/Compiler/DCC/dcc.c`: argument handling, suffix handling, and the link command construction. The KLibc build changes are intended to support that flow without requiring package makefiles to know about `lwasm`/`lwlink` directly.
